### PR TITLE
keyword-first annotation output +  Add TSV exports for easier review and downstream analysis + checks annotators availability

### DIFF
--- a/configs/examples/corpus-file.toml
+++ b/configs/examples/corpus-file.toml
@@ -20,9 +20,10 @@ timeout = 45
 mode = "text_only"
 bioconcept = "All"
 poll_interval_seconds = 2.0
-poll_backoff = 1.5
-max_poll_interval_seconds = 15.0
-max_poll_attempts = 30
+poll_backoff = 1.25
+max_poll_interval_seconds = 5.0
+max_poll_attempts = 12
+max_poll_seconds = 45.0
 
 [filters]
 entity_types = []

--- a/configs/pipeline.toml
+++ b/configs/pipeline.toml
@@ -6,23 +6,25 @@ pmids = ["36403686"]
 sources = []
 
 [annotators]
-enabled = ["pubtator3"]
+enabled = ["bern2", "flair", "pubtator3"]
 
 [annotators.bern2]
-runtime = "docker"
+runtime = "remote_api"
 base_url = "http://127.0.0.1:8888"
 
 [annotators.flair]
-runtime = "python_local"
+model = "hunflair2"
 
 [annotators.pubtator3]
 runtime = "remote_api"
 endpoint = "https://www.ncbi.nlm.nih.gov/research/pubtator3-api"
 format = "biocjson"
 timeout = 60
+mode = "auto"
+bioconcept = "All"
 
 [filters]
 entity_types = []
 
 [output]
-path = "outputs/pubtator3_pipeline_output.json"
+path = "outputs/three_annotators.json"

--- a/configs/pipeline.toml
+++ b/configs/pipeline.toml
@@ -11,6 +11,7 @@ enabled = ["bern2", "flair", "pubtator3"]
 [annotators.bern2]
 runtime = "remote_api"
 base_url = "http://127.0.0.1:8888"
+endpoint = "http://bern2.korea.ac.kr/plain"
 
 [annotators.flair]
 model = "hunflair2"

--- a/configs/pipeline.toml
+++ b/configs/pipeline.toml
@@ -28,4 +28,4 @@ bioconcept = "All"
 entity_types = []
 
 [output]
-path = "outputs/three_annotators.json"
+path = "outputs/annotators_result.json"

--- a/src/bio_annotation/annotators/pubtator3.py
+++ b/src/bio_annotation/annotators/pubtator3.py
@@ -6,8 +6,10 @@ from typing import Any, Callable
 
 from bio_annotation.clients.pubtator3 import (
     DEFAULT_EXPORT_FORMAT,
+    DEFAULT_TEXT_MAX_POLL_SECONDS,
     PUBTATOR3_API_BASE_URL,
     PubTator3Client,
+    PollProgressCallback,
 )
 from bio_annotation.entity_proposal._shared import make_annotation, pick_first
 from bio_annotation.schemas.document import Document
@@ -201,6 +203,8 @@ def call_pubtator3(
     poll_backoff: float = 1.5,
     max_poll_interval_seconds: float = 15.0,
     max_poll_attempts: int = 15,
+    max_poll_seconds: float = DEFAULT_TEXT_MAX_POLL_SECONDS,
+    progress_callback: PollProgressCallback | None = None,
 ) -> Any:
     active_client = client or PubTator3Client(
         base_url=endpoint or os.getenv("PUBTATOR3_API_URL", PUBTATOR3_API_BASE_URL),
@@ -233,6 +237,8 @@ def call_pubtator3(
             poll_interval=poll_interval_seconds,
             poll_backoff=poll_backoff,
             max_poll_interval=max_poll_interval_seconds,
+            max_poll_seconds=max_poll_seconds,
+            progress_callback=progress_callback,
         )
 
     if document.source == "pubmed":
@@ -255,6 +261,8 @@ def call_pubtator3(
         poll_backoff=poll_backoff,
         max_poll_interval_seconds=max_poll_interval_seconds,
         max_poll_attempts=max_poll_attempts,
+        max_poll_seconds=max_poll_seconds,
+        progress_callback=progress_callback,
     )
 
 
@@ -273,6 +281,8 @@ def annotate_with_pubtator3(
     poll_backoff: float = 1.5,
     max_poll_interval_seconds: float = 15.0,
     max_poll_attempts: int = 15,
+    max_poll_seconds: float = DEFAULT_TEXT_MAX_POLL_SECONDS,
+    progress_callback: PollProgressCallback | None = None,
 ) -> list[Annotation]:
     payload = response
     if payload is None and request_fn is not None:
@@ -290,6 +300,8 @@ def annotate_with_pubtator3(
             poll_backoff=poll_backoff,
             max_poll_interval_seconds=max_poll_interval_seconds,
             max_poll_attempts=max_poll_attempts,
+            max_poll_seconds=max_poll_seconds,
+            progress_callback=progress_callback,
         )
     return parse_pubtator3_response(document, payload)
 

--- a/src/bio_annotation/cli.py
+++ b/src/bio_annotation/cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from bio_annotation._cli_arg_validator import positive_int
 from bio_annotation.annotators import flatten_annotations, run_all_annotators
+from bio_annotation._cli_arg_validator import positive_int
 from bio_annotation.io.search import search_pubmed_pmids, write_pmids
 from bio_annotation.pipeline_config import load_pipeline_config
 from bio_annotation.pipeline_runner import run_pipeline_from_config

--- a/src/bio_annotation/cli.py
+++ b/src/bio_annotation/cli.py
@@ -207,11 +207,12 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "run-config":
         try:
+            config = load_pipeline_config(args.config)
             payload = run_pipeline_from_config(args.config)
         except ValueError as exc:
             print(str(exc), file=sys.stderr)
             return 1
-        print(json.dumps(payload, indent=2))
+        print_run_config_summary(payload, config.output_path)
         return 0
 
     if args.command == "search-pmids":
@@ -243,3 +244,34 @@ def main(argv: list[str] | None = None) -> int:
 
     parser.print_help()
     return 1
+
+
+def print_run_config_summary(payload: dict[str, object], output_path: Path | None) -> None:
+    annotation_summary = payload.get("annotation_summary")
+    summary = annotation_summary if isinstance(annotation_summary, dict) else {}
+
+    print("Pipeline completed.")
+    if output_path is not None:
+        print(f"Output written to: {output_path.as_posix()}")
+    else:
+        print("No output path configured; no JSON file was written.")
+
+    print(f"Documents: {payload.get('document_count', 0)}")
+    print(f"Annotations: {summary.get('annotation_count', 0)}")
+    print(f"Keywords: {summary.get('keyword_count', 0)}")
+
+    annotator_summary = payload.get("annotator_summary")
+    if isinstance(annotator_summary, dict):
+        produced = annotator_summary.get("produced")
+        not_produced = annotator_summary.get("not_produced")
+        failed = annotator_summary.get("failed")
+        print(f"Annotators with results: {_format_name_list(produced)}")
+        print(f"Annotators without results: {_format_name_list(not_produced)}")
+        if failed:
+            print(f"Annotators failed: {_format_name_list(failed)}")
+
+
+def _format_name_list(value: object) -> str:
+    if isinstance(value, list) and value:
+        return ", ".join(str(item) for item in value)
+    return "none"

--- a/src/bio_annotation/cli.py
+++ b/src/bio_annotation/cli.py
@@ -249,9 +249,17 @@ def main(argv: list[str] | None = None) -> int:
 def print_run_config_summary(payload: dict[str, object], output_path: Path | None) -> None:
     annotation_summary = payload.get("annotation_summary")
     summary = annotation_summary if isinstance(annotation_summary, dict) else {}
+    output = payload.get("output")
+    actual_output_path = (
+        output.get("path")
+        if isinstance(output, dict)
+        else None
+    )
 
     print("Pipeline completed.")
-    if output_path is not None:
+    if isinstance(actual_output_path, str) and actual_output_path:
+        print(f"Output written to: {actual_output_path}")
+    elif output_path is not None:
         print(f"Output written to: {output_path.as_posix()}")
     else:
         print("No output path configured; no JSON file was written.")

--- a/src/bio_annotation/clients/pubtator3.py
+++ b/src/bio_annotation/clients/pubtator3.py
@@ -19,8 +19,10 @@ DEFAULT_TEXT_MAX_ATTEMPTS = 20
 DEFAULT_TEXT_POLL_INTERVAL = 2.0
 DEFAULT_TEXT_POLL_BACKOFF = 1.5
 DEFAULT_TEXT_MAX_POLL_INTERVAL = 15.0
+DEFAULT_TEXT_MAX_POLL_SECONDS = 180.0
 
 RequestOpener = Callable[[request.Request, int], bytes]
+PollProgressCallback = Callable[[str, int, int, float], None]
 
 
 class PubTator3PendingError(ValueError):
@@ -141,6 +143,8 @@ class PubTator3Client:
         poll_interval: float = DEFAULT_TEXT_POLL_INTERVAL,
         poll_backoff: float = DEFAULT_TEXT_POLL_BACKOFF,
         max_poll_interval: float = DEFAULT_TEXT_MAX_POLL_INTERVAL,
+        max_poll_seconds: float = DEFAULT_TEXT_MAX_POLL_SECONDS,
+        progress_callback: PollProgressCallback | None = None,
     ) -> str:
         if max_attempts < 1:
             raise ValueError("max_attempts must be at least 1.")
@@ -150,22 +154,33 @@ class PubTator3Client:
             raise ValueError("poll_backoff must be at least 1.0.")
         if max_poll_interval <= 0:
             raise ValueError("max_poll_interval must be greater than 0.")
+        if max_poll_seconds <= 0:
+            raise ValueError("max_poll_seconds must be greater than 0.")
 
         session_id = self.submit_text_annotation(payload, bioconcept=bioconcept)
         last_error: PubTator3PendingError | None = None
         delay = poll_interval
+        started_at = time.monotonic()
         for attempt in range(max_attempts):
             try:
                 return self.retrieve_text_annotation(session_id)
             except PubTator3PendingError as exc:
                 last_error = exc
+                elapsed = time.monotonic() - started_at
                 if attempt == max_attempts - 1:
                     break
-                time.sleep(delay)
+                if elapsed >= max_poll_seconds:
+                    break
+                sleep_seconds = min(delay, max_poll_seconds - elapsed)
+                if progress_callback is not None:
+                    progress_callback(session_id, attempt + 1, max_attempts, sleep_seconds)
+                time.sleep(sleep_seconds)
                 delay = min(delay * poll_backoff, max_poll_interval)
 
+        elapsed = time.monotonic() - started_at
         raise ValueError(
-            f"PubTator3 annotation job {session_id} was not ready after {max_attempts} attempts."
+            f"PubTator3 annotation job {session_id} was not ready after "
+            f"{max_attempts} attempts and {elapsed:.1f}s."
         ) from last_error
 
     def _fetch_publications(

--- a/src/bio_annotation/clients/pubtator3.py
+++ b/src/bio_annotation/clients/pubtator3.py
@@ -111,8 +111,13 @@ class PubTator3Client:
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             method="POST",
         )
-        response_body = self._send_json(http_request)
-        session_id = str(response_body.get("id") or "").strip()
+        response_text = self._send_text(http_request).strip()
+        try:
+            response_body = json.loads(response_text)
+        except json.JSONDecodeError:
+            session_id = response_text
+        else:
+            session_id = str(response_body.get("id") or "").strip()
         if not session_id:
             raise ValueError("PubTator3 submit endpoint returned an empty session ID.")
         return session_id

--- a/src/bio_annotation/entity_proposal/bern2_proposer.py
+++ b/src/bio_annotation/entity_proposal/bern2_proposer.py
@@ -82,8 +82,10 @@ def call_bern2(document: Document, endpoint: str | None = None, timeout: int = 3
     try:
         with request.urlopen(http_request, timeout=timeout) as response:
             return json.loads(response.read().decode("utf-8"))
-    except (error.URLError, json.JSONDecodeError):
-        return None
+    except error.URLError as exc:
+        raise ValueError(f"Bern2 request failed: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Bern2 returned invalid JSON: {exc}") from exc
 
 
 def annotate_with_bern2(

--- a/src/bio_annotation/entity_proposal/flair_proposer.py
+++ b/src/bio_annotation/entity_proposal/flair_proposer.py
@@ -84,8 +84,8 @@ def annotate_with_flair(
     spans: Iterable[Any] | None = None,
     tagger: Any = None,
     model: str | None = None,
-    sentence_factory: Callable[[str], Any] | None = None,
     tagger_loader: Callable[[str], Any] | None = None,
+    sentence_factory: Callable[[str], Any] | None = None,
 ) -> list[Annotation]:
     if spans is not None:
         return parse_flair_spans(document, spans)
@@ -105,7 +105,6 @@ def annotate_with_flair(
             sentence = sentence_factory(document.text)
 
         tagger.predict(sentence)
-
         if hasattr(sentence, "get_labels"):
             return parse_flair_labels(document, sentence.get_labels())
         if hasattr(sentence, "get_spans"):

--- a/src/bio_annotation/entity_proposal/flair_proposer.py
+++ b/src/bio_annotation/entity_proposal/flair_proposer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import lru_cache
 from typing import Any, Callable, Iterable
 
 from bio_annotation.entity_proposal._shared import make_annotation
@@ -45,6 +46,13 @@ def parse_flair_spans(document: Document, spans: Iterable[Any]) -> list[Annotati
     return annotations
 
 
+@lru_cache(maxsize=4)
+def _load_flair_tagger(model: str) -> Any:
+    from flair.models import SequenceTagger
+
+    return SequenceTagger.load(model)
+
+
 def parse_flair_labels(document: Document, labels: Iterable[Any]) -> list[Annotation]:
     annotations: list[Annotation] = []
     for label in labels:
@@ -54,6 +62,7 @@ def parse_flair_labels(document: Document, labels: Iterable[Any]) -> list[Annota
         text = getattr(span, "text", None)
         if not text:
             continue
+
         annotations.append(
             make_annotation(
                 document=document,
@@ -65,6 +74,7 @@ def parse_flair_labels(document: Document, labels: Iterable[Any]) -> list[Annota
                 confidence=getattr(label, "score", None),
             )
         )
+
     return annotations
 
 
@@ -73,10 +83,16 @@ def annotate_with_flair(
     *,
     spans: Iterable[Any] | None = None,
     tagger: Any = None,
+    model: str | None = None,
     sentence_factory: Callable[[str], Any] | None = None,
+    tagger_loader: Callable[[str], Any] | None = None,
 ) -> list[Annotation]:
     if spans is not None:
         return parse_flair_spans(document, spans)
+
+    if tagger is None and model:
+        loader = tagger_loader or _load_flair_tagger
+        tagger = loader(model)
 
     if tagger is not None:
         if sentence_factory is None:
@@ -89,6 +105,11 @@ def annotate_with_flair(
             sentence = sentence_factory(document.text)
 
         tagger.predict(sentence)
-        return parse_flair_labels(document, sentence.get_labels())
+
+        if hasattr(sentence, "get_labels"):
+            return parse_flair_labels(document, sentence.get_labels())
+        if hasattr(sentence, "get_spans"):
+            return parse_flair_spans(document, sentence.get_spans("ner"))
+        return []
 
     return []

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -55,6 +55,7 @@ def build_pipeline_output(
     enabled_annotators = list(config.annotators)
     annotator_settings = dict(config.annotator_settings)
     _validate_annotators(enabled_annotators)
+
     input_description = resolve_input_description(config)
     corpus_documents = [document_to_dict(document) for document in documents]
     pubtator3_options = _read_pubtator3_options(annotator_settings.get("pubtator3", {}))
@@ -69,11 +70,15 @@ def build_pipeline_output(
 
     document_annotations: list[dict[str, Any]] = []
     annotations_output: list[dict[str, Any]] = []
+    keywords_output: list[dict[str, Any]] = []
+
     annotation_summary = {
         "annotators_enabled": enabled_annotators,
         "document_count": len(documents),
         "annotation_count": 0,
+        "keyword_count": 0,
     }
+
     for document in documents:
         results = run_selected_annotators(
             document,
@@ -88,18 +93,26 @@ def build_pipeline_output(
             ),
             flair_tagger=flair_tagger,
         )
+
         annotations = flatten_annotations(results)
         annotations = filter_annotations_by_type(annotations, config.entity_types)
+        keyword_annotations = build_keyword_annotations(document.document_id, annotations)
+
         annotation_summary["annotation_count"] += len(annotations)
+        annotation_summary["keyword_count"] += len(keyword_annotations)
+
         if enabled_annotators:
             document_annotations.append(
                 {
                     "document_id": document.document_id,
                     "sources": sorted(results),
                     "annotation_count": len(annotations),
+                    "keyword_count": len(keyword_annotations),
+                    "keywords": keyword_annotations,
                     "annotations": [annotation.to_dict() for annotation in annotations],
                 }
             )
+
         annotations_output.extend(
             {
                 "document_id": document.document_id,
@@ -107,6 +120,7 @@ def build_pipeline_output(
             }
             for annotation in annotations
         )
+        keywords_output.extend(keyword_annotations)
 
     return {
         "stage": "corpus",
@@ -114,7 +128,9 @@ def build_pipeline_output(
         "pipeline": {
             "mode": "ingestion_only" if not enabled_annotators else "ingestion_and_annotation",
             "annotators_enabled": enabled_annotators,
-            "annotator_settings": {name: annotator_settings.get(name, {}) for name in enabled_annotators},
+            "annotator_settings": {
+                name: annotator_settings.get(name, {}) for name in enabled_annotators
+            },
         },
         "document_count": len(corpus_documents),
         "corpus_summary": summarize_ingestion(documents),
@@ -122,6 +138,7 @@ def build_pipeline_output(
         "documents": corpus_documents,
         "annotation_summary": annotation_summary,
         "document_annotations": document_annotations,
+        "keywords": keywords_output,
         "annotations": annotations_output,
     }
 
@@ -158,13 +175,19 @@ def run_selected_annotators(
                 request_fn=pubtator3_request_fn,
                 endpoint=pubtator3_options.get("endpoint") if pubtator3_options else None,
                 timeout=pubtator3_options.get("timeout", 60) if pubtator3_options else 60,
-                format=pubtator3_options.get("format", "biocjson") if pubtator3_options else "biocjson",
+                format=pubtator3_options.get("format", "biocjson")
+                if pubtator3_options
+                else "biocjson",
                 mode=pubtator3_options.get("mode", "auto") if pubtator3_options else "auto",
-                bioconcept=pubtator3_options.get("bioconcept", "All") if pubtator3_options else "All",
+                bioconcept=pubtator3_options.get("bioconcept", "All")
+                if pubtator3_options
+                else "All",
                 poll_interval_seconds=pubtator3_options.get("poll_interval_seconds", 2.0)
                 if pubtator3_options
                 else 2.0,
-                poll_backoff=pubtator3_options.get("poll_backoff", 1.5) if pubtator3_options else 1.5,
+                poll_backoff=pubtator3_options.get("poll_backoff", 1.5)
+                if pubtator3_options
+                else 1.5,
                 max_poll_interval_seconds=(
                     pubtator3_options.get("max_poll_interval_seconds", 15.0)
                     if pubtator3_options
@@ -187,9 +210,84 @@ def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation
     return annotations
 
 
-def filter_annotations_by_type(annotations: list[Annotation], entity_types: list[str]) -> list[Annotation]:
+def build_keyword_annotations(
+    document_id: str,
+    annotations: list[Annotation],
+) -> list[dict[str, Any]]:
+    groups: dict[tuple[str, str, int | None, int | None], dict[str, Any]] = {}
+
+    for annotation in annotations:
+        keyword = annotation.span_text.strip()
+        if not keyword:
+            continue
+
+        key = (document_id, keyword.casefold(), annotation.start, annotation.end)
+
+        if key not in groups:
+            groups[key] = {
+                "document_id": document_id,
+                "keyword": keyword,
+                "start": annotation.start,
+                "end": annotation.end,
+                "annotation_count": 0,
+                "annotator_count": 0,
+                "labels": [],
+                "canonical_ids": [],
+                "annotators": [],
+            }
+
+        group = groups[key]
+        group["annotation_count"] += 1
+        group["annotators"].append(
+            {
+                "source": annotation.source,
+                "label": annotation.entity_type,
+                "annotation_id": annotation.annotation_id,
+                "canonical_id": annotation.canonical_id,
+                "canonical_name": annotation.canonical_name,
+                "confidence": annotation.confidence,
+            }
+        )
+
+    for group in groups.values():
+        group["annotators"] = sorted(
+            group["annotators"],
+            key=lambda item: (
+                item["source"],
+                item["label"],
+                item["annotation_id"],
+            ),
+        )
+        group["annotator_count"] = len({item["source"] for item in group["annotators"]})
+        group["labels"] = sorted({item["label"] for item in group["annotators"]})
+        group["canonical_ids"] = sorted(
+            {
+                item["canonical_id"]
+                for item in group["annotators"]
+                if item["canonical_id"] is not None
+            }
+        )
+
+    return sorted(
+        groups.values(),
+        key=lambda item: (
+            item["document_id"],
+            item["start"] is None,
+            item["start"] if item["start"] is not None else -1,
+            item["end"] is None,
+            item["end"] if item["end"] is not None else -1,
+            item["keyword"].casefold(),
+        ),
+    )
+
+
+def filter_annotations_by_type(
+    annotations: list[Annotation],
+    entity_types: list[str],
+) -> list[Annotation]:
     if not entity_types:
         return annotations
+
     allowed = set(entity_types)
     return [annotation for annotation in annotations if annotation.entity_type in allowed]
 

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import csv
 import json
 from pathlib import Path
 from typing import Any, Callable
@@ -57,16 +58,16 @@ def build_pipeline_output(
     _validate_annotators(enabled_annotators)
     input_description = resolve_input_description(config)
     corpus_documents = [document_to_dict(document) for document in documents]
+    bern2_options = _read_bern2_options(annotator_settings.get("bern2", {}))
     pubtator3_options = _read_pubtator3_options(annotator_settings.get("pubtator3", {}))
     flair_options = _read_flair_options(annotator_settings.get("flair", {}))
 
     flair_tagger = None
-    if (
-        "flair" in enabled_annotators
-        and flair_spans_by_document is None
-    ):
-        flair_tagger = _load_flair_tagger(flair_options["model"])
-
+    if "flair" in enabled_annotators and flair_spans_by_document is None:
+        try:
+            flair_tagger = _load_flair_tagger(flair_options["model"])
+        except Exception as exc:
+            print(f"flair unavailable: {exc}")
     document_annotations: list[dict[str, Any]] = []
     annotations_output: list[dict[str, Any]] = []
     annotation_summary = {
@@ -80,6 +81,7 @@ def build_pipeline_output(
             enabled_annotators,
             bern2_request_fn=bern2_request_fn,
             pubtator3_request_fn=pubtator3_request_fn,
+            bern2_options=bern2_options,
             pubtator3_options=pubtator3_options,
             flair_spans=(
                 flair_spans_by_document.get(document.document_id)
@@ -129,6 +131,186 @@ def build_pipeline_output(
 def write_pipeline_output(payload: dict[str, Any], output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    write_pipeline_tsv_outputs(payload, output_path)
+
+
+def write_pipeline_tsv_outputs(payload: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    write_keywords_tsv(
+        payload,
+        output_path.with_name(f"{output_path.stem}.keywords.tsv"),
+    )
+    write_keyword_annotator_evidence_tsv(
+        payload,
+        output_path.with_name(f"{output_path.stem}.keyword_annotator_evidence.tsv"),
+    )
+    write_annotations_tsv(
+        payload,
+        output_path.with_name(f"{output_path.stem}.annotations.tsv"),
+    )
+
+
+def write_keywords_tsv(payload: dict[str, Any], output_path: Path) -> None:
+    documents = _documents_by_id(payload)
+    rows: list[dict[str, Any]] = []
+
+    for keyword in payload.get("keywords", []):
+        if not isinstance(keyword, dict):
+            continue
+
+        document_id = str(keyword.get("document_id") or "")
+        document = documents.get(document_id, {})
+        annotators = [
+            item
+            for item in keyword.get("annotators", [])
+            if isinstance(item, dict)
+        ]
+
+        rows.append(
+            {
+                "document_id": document_id,
+                "pmid": document.get("pmid"),
+                "title": document.get("title"),
+                "keyword": keyword.get("keyword"),
+                "start": keyword.get("start"),
+                "end": keyword.get("end"),
+                "annotation_count": keyword.get("annotation_count"),
+                "annotator_count": keyword.get("annotator_count"),
+                "labels": _join_values(keyword.get("labels")),
+                "canonical_ids": _join_values(keyword.get("canonical_ids")),
+                "sources": _join_values(
+                    sorted(
+                        {
+                            item.get("source")
+                            for item in annotators
+                            if item.get("source")
+                        }
+                    )
+                ),
+            }
+        )
+
+    _write_tsv(
+        output_path,
+        [
+            "document_id",
+            "pmid",
+            "title",
+            "keyword",
+            "start",
+            "end",
+            "annotation_count",
+            "annotator_count",
+            "labels",
+            "canonical_ids",
+            "sources",
+        ],
+        rows,
+    )
+
+
+def write_keyword_annotator_evidence_tsv(
+    payload: dict[str, Any],
+    output_path: Path,
+) -> None:
+    documents = _documents_by_id(payload)
+    rows: list[dict[str, Any]] = []
+
+    for keyword in payload.get("keywords", []):
+        if not isinstance(keyword, dict):
+            continue
+
+        document_id = str(keyword.get("document_id") or "")
+        document = documents.get(document_id, {})
+
+        for item in keyword.get("annotators", []):
+            if not isinstance(item, dict):
+                continue
+
+            rows.append(
+                {
+                    "document_id": document_id,
+                    "pmid": document.get("pmid"),
+                    "title": document.get("title"),
+                    "keyword": keyword.get("keyword"),
+                    "start": keyword.get("start"),
+                    "end": keyword.get("end"),
+                    "source": item.get("source"),
+                    "label": item.get("label"),
+                    "annotation_id": item.get("annotation_id"),
+                    "canonical_id": item.get("canonical_id"),
+                    "canonical_name": item.get("canonical_name"),
+                    "confidence": item.get("confidence"),
+                }
+            )
+
+    _write_tsv(
+        output_path,
+        [
+            "document_id",
+            "pmid",
+            "title",
+            "keyword",
+            "start",
+            "end",
+            "source",
+            "label",
+            "annotation_id",
+            "canonical_id",
+            "canonical_name",
+            "confidence",
+        ],
+        rows,
+    )
+
+
+def write_annotations_tsv(payload: dict[str, Any], output_path: Path) -> None:
+    documents = _documents_by_id(payload)
+    rows: list[dict[str, Any]] = []
+
+    for annotation in payload.get("annotations", []):
+        if not isinstance(annotation, dict):
+            continue
+
+        document_id = str(annotation.get("document_id") or "")
+        document = documents.get(document_id, {})
+
+        rows.append(
+            {
+                "document_id": document_id,
+                "pmid": document.get("pmid"),
+                "title": document.get("title"),
+                "source": annotation.get("source"),
+                "span_text": annotation.get("span_text"),
+                "start": annotation.get("start"),
+                "end": annotation.get("end"),
+                "entity_type": annotation.get("entity_type"),
+                "annotation_id": annotation.get("annotation_id"),
+                "canonical_id": annotation.get("canonical_id"),
+                "canonical_name": annotation.get("canonical_name"),
+                "confidence": annotation.get("confidence"),
+            }
+        )
+
+    _write_tsv(
+        output_path,
+        [
+            "document_id",
+            "pmid",
+            "title",
+            "source",
+            "span_text",
+            "start",
+            "end",
+            "entity_type",
+            "annotation_id",
+            "canonical_id",
+            "canonical_name",
+            "confidence",
+        ],
+        rows,
+    )
 
 
 def run_selected_annotators(
@@ -137,6 +319,7 @@ def run_selected_annotators(
     *,
     bern2_request_fn: Callable[[Document], Any] | None = None,
     pubtator3_request_fn: Callable[[Document], Any] | None = None,
+    bern2_options: dict[str, Any] | None = None,
     pubtator3_options: dict[str, Any] | None = None,
     flair_spans: list[Any] | None = None,
     flair_tagger: Any = None,
@@ -149,6 +332,11 @@ def run_selected_annotators(
                 results[annotator] = annotate_with_bern2(
                     document,
                     request_fn=bern2_request_fn,
+                    endpoint=(
+                        bern2_options.get("endpoint")
+                        if bern2_options
+                        else None
+                    ),
                 )
             elif annotator == "flair":
                 results[annotator] = annotate_with_flair(
@@ -204,6 +392,7 @@ def run_selected_annotators(
 
     return results
 
+
 def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation]:
     annotations: list[Annotation] = []
     for source in ("bern2", "flair", "pubtator3"):
@@ -231,10 +420,66 @@ def document_to_dict(document: Document) -> dict[str, Any]:
     }
 
 
+def _documents_by_id(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    documents: dict[str, dict[str, Any]] = {}
+    for document in payload.get("documents", []):
+        if not isinstance(document, dict):
+            continue
+        document_id = document.get("document_id")
+        if document_id is not None:
+            documents[str(document_id)] = document
+    return documents
+
+
+def _join_values(values: object) -> str:
+    if values is None:
+        return ""
+    if isinstance(values, list | tuple | set):
+        return "|".join(str(value) for value in values if value is not None)
+    return str(values)
+
+
+def _write_tsv(
+    output_path: Path,
+    fieldnames: list[str],
+    rows: list[dict[str, Any]],
+) -> None:
+    with output_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=fieldnames,
+            delimiter="\t",
+            extrasaction="ignore",
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
 def _validate_annotators(annotators: list[str]) -> None:
     unsupported = [annotator for annotator in annotators if annotator not in SUPPORTED_ANNOTATORS]
     if unsupported:
         raise ValueError(f"Unsupported annotators requested: {', '.join(unsupported)}")
+
+
+def _read_bern2_options(settings: dict[str, object]) -> dict[str, Any]:
+    endpoint = settings.get("endpoint")
+    base_url = settings.get("base_url")
+    timeout = settings.get("timeout")
+
+    cleaned_endpoint = None
+    if isinstance(endpoint, str) and endpoint.strip():
+        cleaned_endpoint = endpoint.strip()
+    elif isinstance(base_url, str) and base_url.strip():
+        cleaned_endpoint = base_url.strip()
+
+    return {
+        "endpoint": cleaned_endpoint,
+        "timeout": (
+            int(timeout)
+            if isinstance(timeout, int) and timeout > 0
+            else 30
+        ),
+    }
 
 
 def _read_flair_options(settings: dict[str, object]) -> dict[str, Any]:
@@ -248,24 +493,6 @@ def _load_flair_tagger(model: str) -> Any:
     from flair.nn import Classifier
 
     return Classifier.load(model)
-
-
-def _read_bern2_options(settings: dict[str, object]) -> dict[str, Any]:
-    base_url = settings.get("base_url")
-    timeout = settings.get("timeout")
-
-    return {
-        "base_url": (
-            base_url.strip()
-            if isinstance(base_url, str) and base_url.strip()
-            else "http://127.0.0.1:8888"
-        ),
-        "timeout": (
-            int(timeout)
-            if isinstance(timeout, int) and timeout > 0
-            else 60
-        ),
-    }
 
 
 def _read_pubtator3_options(settings: dict[str, object]) -> dict[str, Any]:

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import csv
 import json
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
 
@@ -42,7 +43,13 @@ def run_pipeline_from_config(
         flair_spans_by_document=flair_spans_by_document,
     )
     if config.output_path is not None:
-        write_pipeline_output(payload, config.output_path)
+        actual_output_path = timestamped_output_path(config.output_path)
+        payload["output"] = {
+            "configured_path": config.output_path.as_posix(),
+            "path": actual_output_path.as_posix(),
+            "run_dir": actual_output_path.parent.as_posix(),
+        }
+        write_pipeline_output(payload, actual_output_path)
     return payload
 
 
@@ -146,6 +153,11 @@ def write_pipeline_output(payload: dict[str, Any], output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     write_pipeline_tsv_outputs(payload, output_path)
+
+
+def timestamped_output_path(output_path: Path, *, now: datetime | None = None) -> Path:
+    stamp = (now or datetime.now()).strftime("%Y%m%d-%H%M%S")
+    return output_path.parent / stamp / output_path.name
 
 
 def write_pipeline_tsv_outputs(payload: dict[str, Any], output_path: Path) -> None:

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -1,483 +1,115 @@
 from __future__ import annotations
 
-import json
-from pathlib import Path
-from typing import Any, Callable
+from functools import lru_cache
+from typing import Any, Callable, Iterable
 
-from bio_annotation.annotators.bern2 import annotate_with_bern2
-from bio_annotation.annotators.flair import annotate_with_flair
-from bio_annotation.annotators.pubtator3 import annotate_with_pubtator3
-from bio_annotation.pipeline_config import PipelineConfig, load_pipeline_config
-from bio_annotation.preprocessing.document_loader import (
-    load_documents_from_config,
-    resolve_input_description,
-    summarize_ingestion,
-)
+from bio_annotation.entity_proposal._shared import make_annotation
 from bio_annotation.schemas.document import Document
 from bio_annotation.schemas.entity import Annotation
 
-SUPPORTED_ANNOTATORS = {"bern2", "flair", "pubtator3"}
+
+def _extract_flair_label(span: Any) -> tuple[Any, Any]:
+    if hasattr(span, "get_label"):
+        label = span.get_label("ner")
+        return getattr(label, "value", None), getattr(label, "score", None)
+
+    labels = getattr(span, "labels", None)
+    if labels:
+        first = labels[0]
+        return getattr(first, "value", None), getattr(first, "score", None)
+
+    return getattr(span, "tag", None), getattr(span, "score", None)
 
 
-def run_pipeline_from_config(
-    config_path: Path,
-    *,
-    orchestrator_factory: Callable[[], Any] | None = None,
-    bern2_request_fn: Callable[[Document], Any] | None = None,
-    pubtator3_request_fn: Callable[[Document], Any] | None = None,
-    flair_spans_by_document: dict[str, list[Any]] | None = None,
-) -> dict[str, Any]:
-    config = load_pipeline_config(config_path)
-    documents = load_documents_from_config(
-        config,
-        orchestrator_factory=orchestrator_factory,
-    )
-    payload = build_pipeline_output(
-        documents,
-        config,
-        bern2_request_fn=bern2_request_fn,
-        pubtator3_request_fn=pubtator3_request_fn,
-        flair_spans_by_document=flair_spans_by_document,
-    )
-    if config.output_path is not None:
-        write_pipeline_output(payload, config.output_path)
-    return payload
-
-
-def build_pipeline_output(
-    documents: list[Document],
-    config: PipelineConfig,
-    *,
-    bern2_request_fn: Callable[[Document], Any] | None = None,
-    pubtator3_request_fn: Callable[[Document], Any] | None = None,
-    flair_spans_by_document: dict[str, list[Any]] | None = None,
-) -> dict[str, Any]:
-    enabled_annotators = list(config.annotators)
-    annotator_settings = dict(config.annotator_settings)
-    _validate_annotators(enabled_annotators)
-
-    input_description = resolve_input_description(config)
-    corpus_documents = [document_to_dict(document) for document in documents]
-    pubtator3_options = _read_pubtator3_options(annotator_settings.get("pubtator3", {}))
-    flair_options = _read_flair_options(annotator_settings.get("flair", {}))
-
-    flair_tagger = None
-    if (
-        "flair" in enabled_annotators
-        and flair_spans_by_document is None
-    ):
-        flair_tagger = _load_flair_tagger(flair_options["model"])
-
-    document_annotations: list[dict[str, Any]] = []
-    annotations_output: list[dict[str, Any]] = []
-    keywords_output: list[dict[str, Any]] = []
-
-    annotation_summary = {
-        "annotators_enabled": enabled_annotators,
-        "document_count": len(documents),
-        "annotation_count": 0,
-        "keyword_count": 0,
-    }
-
-    for document in documents:
-        results = run_selected_annotators(
-            document,
-            enabled_annotators,
-            bern2_request_fn=bern2_request_fn,
-            pubtator3_request_fn=pubtator3_request_fn,
-            pubtator3_options=pubtator3_options,
-            flair_spans=(
-                flair_spans_by_document.get(document.document_id)
-                if flair_spans_by_document is not None
-                else None
-            ),
-            flair_tagger=flair_tagger,
-        )
-
-        annotations = flatten_annotations(results)
-        annotations = filter_annotations_by_type(annotations, config.entity_types)
-        keyword_annotations = build_keyword_annotations(document.document_id, annotations)
-
-        annotation_summary["annotation_count"] += len(annotations)
-        annotation_summary["keyword_count"] += len(keyword_annotations)
-
-        if enabled_annotators:
-            document_annotations.append(
-                {
-                    "document_id": document.document_id,
-                    "sources": sorted({annotation.source for annotation in annotations}),
-                    "annotation_count": len(annotations),
-                    "keyword_count": len(keyword_annotations),
-                    "keywords": keyword_annotations,
-                    "annotations": [annotation.to_dict() for annotation in annotations],
-                }
-            )
-
-        annotations_output.extend(
-            {
-                "document_id": document.document_id,
-                **annotation.to_dict(),
-            }
-            for annotation in annotations
-        )
-        keywords_output.extend(keyword_annotations)
-
-    return {
-        "stage": "corpus",
-        "input": input_description,
-        "pipeline": {
-            "mode": "ingestion_only" if not enabled_annotators else "ingestion_and_annotation",
-            "annotators_enabled": enabled_annotators,
-        },
-        "document_count": len(corpus_documents),
-        "corpus_summary": summarize_ingestion(documents),
-        "entity_types": config.entity_types,
-        "documents": corpus_documents,
-        "annotation_summary": annotation_summary,
-        "document_annotations": document_annotations,
-        "keywords": keywords_output,
-        "annotations": annotations_output,
-    }
-
-
-def write_pipeline_output(payload: dict[str, Any], output_path: Path) -> None:
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-
-
-def run_selected_annotators(
-    document: Document,
-    annotators: list[str],
-    *,
-    bern2_request_fn: Callable[[Document], Any] | None = None,
-    pubtator3_request_fn: Callable[[Document], Any] | None = None,
-    pubtator3_options: dict[str, Any] | None = None,
-    flair_spans: list[Any] | None = None,
-    flair_tagger: Any = None,
-) -> dict[str, list[Annotation]]:
-    results: dict[str, list[Annotation]] = {}
-
-    for annotator in annotators:
-        if annotator == "bern2":
-            results[annotator] = annotate_with_bern2(document, request_fn=bern2_request_fn)
-        elif annotator == "flair":
-            results[annotator] = annotate_with_flair(
-                document,
-                spans=flair_spans,
-                tagger=flair_tagger,
-            )
-        elif annotator == "pubtator3":
-            results[annotator] = annotate_with_pubtator3(
-                document,
-                request_fn=pubtator3_request_fn,
-                endpoint=pubtator3_options.get("endpoint") if pubtator3_options else None,
-                timeout=pubtator3_options.get("timeout", 60) if pubtator3_options else 60,
-                format=pubtator3_options.get("format", "biocjson")
-                if pubtator3_options
-                else "biocjson",
-                mode=pubtator3_options.get("mode", "auto") if pubtator3_options else "auto",
-                bioconcept=pubtator3_options.get("bioconcept", "All")
-                if pubtator3_options
-                else "All",
-                poll_interval_seconds=pubtator3_options.get("poll_interval_seconds", 2.0)
-                if pubtator3_options
-                else 2.0,
-                poll_backoff=pubtator3_options.get("poll_backoff", 1.5)
-                if pubtator3_options
-                else 1.5,
-                max_poll_interval_seconds=(
-                    pubtator3_options.get("max_poll_interval_seconds", 15.0)
-                    if pubtator3_options
-                    else 15.0
-                ),
-                max_poll_attempts=pubtator3_options.get("max_poll_attempts", 15)
-                if pubtator3_options
-                else 15,
-            )
-        else:
-            raise ValueError(f"Unsupported annotator: {annotator}")
-
-    return results
-
-
-def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation]:
+def parse_flair_spans(document: Document, spans: Iterable[Any]) -> list[Annotation]:
     annotations: list[Annotation] = []
-    for source in ("bern2", "flair", "pubtator3"):
-        annotations.extend(results.get(source, []))
+    for span in spans:
+        label, score = _extract_flair_label(span)
+        text = getattr(span, "text", None)
+        if text is None and hasattr(span, "to_original_text"):
+            text = span.to_original_text()
+        if not text:
+            continue
+
+        annotations.append(
+            make_annotation(
+                document=document,
+                source="flair",
+                span_text=text,
+                entity_type=label,
+                start=getattr(span, "start_position", None),
+                end=getattr(span, "end_position", None),
+                confidence=score,
+            )
+        )
+
     return annotations
 
 
-def build_keyword_annotations(
-    document_id: str,
-    annotations: list[Annotation],
-) -> list[dict[str, Any]]:
-    groups: dict[tuple[str, str], dict[str, Any]] = {}
+@lru_cache(maxsize=4)
+def _load_flair_tagger(model: str) -> Any:
+    from flair.models import SequenceTagger
 
-    for annotation in annotations:
-        keyword = annotation.span_text.strip()
-        if not keyword:
+    return SequenceTagger.load(model)
+
+
+def parse_flair_labels(document: Document, labels: Iterable[Any]) -> list[Annotation]:
+    annotations: list[Annotation] = []
+    for label in labels:
+        span = getattr(label, "data_point", None)
+        if span is None:
+            continue
+        text = getattr(span, "text", None)
+        if not text:
             continue
 
-        normalized_keyword = keyword.casefold()
-        key = (document_id, normalized_keyword)
-
-        if key not in groups:
-            groups[key] = {
-                "document_id": document_id,
-                "keyword": keyword,
-                "normalized_keyword": normalized_keyword,
-                "variants": [],
-                "mention_count": 0,
-                "annotation_count": 0,
-                "annotator_count": 0,
-                "labels": [],
-                "canonical_ids": [],
-                "canonical_names": [],
-                "annotators": [],
-                "mentions": [],
-            }
-
-        group = groups[key]
-        group["annotation_count"] += 1
-        if keyword not in group["variants"]:
-            group["variants"].append(keyword)
-
-        mention = _find_keyword_mention(group["mentions"], keyword, annotation.start, annotation.end)
-        if mention is None:
-            mention = {
-                "text": keyword,
-                "start": annotation.start,
-                "end": annotation.end,
-                "annotation_count": 0,
-                "annotator_count": 0,
-                "labels": [],
-                "canonical_ids": [],
-                "canonical_names": [],
-                "annotators": [],
-            }
-            group["mentions"].append(mention)
-
-        mention["annotation_count"] += 1
-        evidence = {
-            "source": annotation.source,
-            "label": annotation.entity_type,
-            "annotation_id": annotation.annotation_id,
-            "canonical_id": annotation.canonical_id,
-            "canonical_name": annotation.canonical_name,
-            "confidence": annotation.confidence,
-        }
-        mention["annotators"].append(evidence)
-        group["annotators"].append(
-            {
-                "source": annotation.source,
-                "label": annotation.entity_type,
-                "canonical_id": annotation.canonical_id,
-                "canonical_name": annotation.canonical_name,
-                "annotation_id": annotation.annotation_id,
-                "mention": {
-                    "text": keyword,
-                    "start": annotation.start,
-                    "end": annotation.end,
-                },
-                "confidence": annotation.confidence,
-            }
+        annotations.append(
+            make_annotation(
+                document=document,
+                source="flair",
+                span_text=text,
+                entity_type=getattr(label, "value", None),
+                start=getattr(span, "start_position", None),
+                end=getattr(span, "end_position", None),
+                confidence=getattr(label, "score", None),
+            )
         )
 
-    for group in groups.values():
-        group["variants"] = sorted(group["variants"], key=lambda item: (item.casefold(), item))
-        group["mention_count"] = len(group["mentions"])
-        group["mentions"] = sorted(
-            (_finalize_keyword_rollup(mention) for mention in group["mentions"]),
-            key=lambda item: (
-                item["start"] is None,
-                item["start"] if item["start"] is not None else -1,
-                item["end"] is None,
-                item["end"] if item["end"] is not None else -1,
-                item["text"].casefold(),
-            ),
-        )
-        group["annotators"] = sorted(
-            group["annotators"],
-            key=lambda item: (
-                item["source"],
-                item["label"],
-                item["canonical_id"] or "",
-                item["annotation_id"],
-            ),
-        )
-        _finalize_keyword_rollup(group)
-        group["annotators"] = _build_annotator_summaries(group["annotators"])
-
-    return sorted(
-        groups.values(),
-        key=lambda item: (
-            item["document_id"],
-            item["keyword"].casefold(),
-        ),
-    )
+    return annotations
 
 
-def _find_keyword_mention(
-    mentions: list[dict[str, Any]],
-    text: str,
-    start: int | None,
-    end: int | None,
-) -> dict[str, Any] | None:
-    normalized_text = text.casefold()
-    for mention in mentions:
-        if (
-            mention["text"].casefold() == normalized_text
-            and mention["start"] == start
-            and mention["end"] == end
-        ):
-            return mention
-    return None
-
-
-def _finalize_keyword_rollup(group: dict[str, Any]) -> dict[str, Any]:
-    group["annotators"] = sorted(
-        group["annotators"],
-        key=lambda item: (
-            item["source"],
-            item["label"],
-            item["canonical_id"] or "",
-            item["annotation_id"],
-        ),
-    )
-    group["annotator_count"] = len({item["source"] for item in group["annotators"]})
-    group["labels"] = sorted({item["label"] for item in group["annotators"]})
-    group["canonical_ids"] = sorted(
-        {
-            item["canonical_id"]
-            for item in group["annotators"]
-            if item["canonical_id"] is not None
-        }
-    )
-    group["canonical_names"] = sorted(
-        {
-            item["canonical_name"]
-            for item in group["annotators"]
-            if item["canonical_name"] is not None
-        }
-    )
-    return group
-
-
-def _build_annotator_summaries(evidence_items: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    summaries: dict[str, dict[str, Any]] = {}
-
-    for evidence in evidence_items:
-        source = evidence["source"]
-        if source not in summaries:
-            summaries[source] = {
-                "source": source,
-                "annotation_count": 0,
-                "labels": [],
-                "canonical_ids": [],
-                "canonical_names": [],
-            }
-
-        summary = summaries[source]
-        summary["annotation_count"] += 1
-        summary["labels"].append(evidence["label"])
-        if evidence["canonical_id"] is not None:
-            summary["canonical_ids"].append(evidence["canonical_id"])
-        if evidence["canonical_name"] is not None:
-            summary["canonical_names"].append(evidence["canonical_name"])
-
-    for summary in summaries.values():
-        summary["labels"] = sorted(set(summary["labels"]))
-        summary["canonical_ids"] = sorted(set(summary["canonical_ids"]))
-        summary["canonical_names"] = sorted(set(summary["canonical_names"]))
-
-    return sorted(summaries.values(), key=lambda item: item["source"])
-
-
-def filter_annotations_by_type(
-    annotations: list[Annotation],
-    entity_types: list[str],
+def annotate_with_flair(
+    document: Document,
+    *,
+    spans: Iterable[Any] | None = None,
+    tagger: Any = None,
+    model: str | None = None,
+    sentence_factory: Callable[[str], Any] | None = None,
+    tagger_loader: Callable[[str], Any] | None = None,
 ) -> list[Annotation]:
-    if not entity_types:
-        return annotations
+    if spans is not None:
+        return parse_flair_spans(document, spans)
 
-    allowed = set(entity_types)
-    return [annotation for annotation in annotations if annotation.entity_type in allowed]
+    if tagger is None and model:
+        loader = tagger_loader or _load_flair_tagger
+        tagger = loader(model)
 
+    if tagger is not None:
+        if sentence_factory is None:
+            try:
+                from flair.data import Sentence
+            except ImportError:
+                return []
+            sentence = Sentence(document.text)
+        else:
+            sentence = sentence_factory(document.text)
 
-def document_to_dict(document: Document) -> dict[str, Any]:
-    return {
-        "document_id": document.document_id,
-        "pmid": document.pmid,
-        "title": document.title,
-        "abstract": document.abstract,
-        "full_text": document.full_text,
-        "source": document.source,
-        "year": document.year,
-        "metadata": document.metadata,
-    }
+        tagger.predict(sentence)
 
+        if hasattr(sentence, "get_labels"):
+            return parse_flair_labels(document, sentence.get_labels())
+        if hasattr(sentence, "get_spans"):
+            return parse_flair_spans(document, sentence.get_spans("ner"))
+        return []
 
-def _validate_annotators(annotators: list[str]) -> None:
-    unsupported = [annotator for annotator in annotators if annotator not in SUPPORTED_ANNOTATORS]
-    if unsupported:
-        raise ValueError(f"Unsupported annotators requested: {', '.join(unsupported)}")
-
-
-def _read_flair_options(settings: dict[str, object]) -> dict[str, Any]:
-    model = settings.get("model")
-    return {
-        "model": model.strip() if isinstance(model, str) and model.strip() else "hunflair2",
-    }
-
-
-def _load_flair_tagger(model: str) -> Any:
-    from flair.nn import Classifier
-
-    return Classifier.load(model)
-
-
-def _read_pubtator3_options(settings: dict[str, object]) -> dict[str, Any]:
-    endpoint = settings.get("endpoint")
-    timeout = settings.get("timeout")
-    export_format = settings.get("format")
-    mode = settings.get("mode")
-    bioconcept = settings.get("bioconcept")
-    poll_interval_seconds = settings.get("poll_interval_seconds")
-    poll_backoff = settings.get("poll_backoff")
-    max_poll_interval_seconds = settings.get("max_poll_interval_seconds")
-    max_poll_attempts = settings.get("max_poll_attempts")
-
-    cleaned_mode = mode.strip().lower() if isinstance(mode, str) and mode.strip() else "auto"
-    if cleaned_mode not in {"auto", "publication_only", "text_only"}:
-        raise ValueError(
-            "annotators.pubtator3.mode must be one of: "
-            "'auto', 'publication_only', 'text_only'."
-        )
-
-    return {
-        "endpoint": endpoint if isinstance(endpoint, str) and endpoint.strip() else None,
-        "timeout": timeout if isinstance(timeout, int) and timeout > 0 else 60,
-        "format": export_format if isinstance(export_format, str) and export_format.strip() else "biocjson",
-        "mode": cleaned_mode,
-        "bioconcept": bioconcept if isinstance(bioconcept, str) and bioconcept.strip() else "All",
-        "poll_interval_seconds": (
-            float(poll_interval_seconds)
-            if isinstance(poll_interval_seconds, (int, float)) and poll_interval_seconds > 0
-            else 2.0
-        ),
-        "poll_backoff": (
-            float(poll_backoff)
-            if isinstance(poll_backoff, (int, float)) and float(poll_backoff) >= 1.0
-            else 1.5
-        ),
-        "max_poll_interval_seconds": (
-            float(max_poll_interval_seconds)
-            if isinstance(max_poll_interval_seconds, (int, float)) and float(max_poll_interval_seconds) > 0
-            else 15.0
-        ),
-        "max_poll_attempts": (
-            int(max_poll_attempts)
-            if isinstance(max_poll_attempts, int) and max_poll_attempts > 0
-            else 15
-        ),
-    }
+    return []

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -144,41 +144,65 @@ def run_selected_annotators(
     results: dict[str, list[Annotation]] = {}
 
     for annotator in annotators:
-        if annotator == "bern2":
-            results[annotator] = annotate_with_bern2(document, request_fn=bern2_request_fn)
-        elif annotator == "flair":
-            results[annotator] = annotate_with_flair(
-                document,
-                spans=flair_spans,
-                tagger=flair_tagger,
-            )
-        elif annotator == "pubtator3":
-            results[annotator] = annotate_with_pubtator3(
-                document,
-                request_fn=pubtator3_request_fn,
-                endpoint=pubtator3_options.get("endpoint") if pubtator3_options else None,
-                timeout=pubtator3_options.get("timeout", 60) if pubtator3_options else 60,
-                format=pubtator3_options.get("format", "biocjson") if pubtator3_options else "biocjson",
-                mode=pubtator3_options.get("mode", "auto") if pubtator3_options else "auto",
-                bioconcept=pubtator3_options.get("bioconcept", "All") if pubtator3_options else "All",
-                poll_interval_seconds=pubtator3_options.get("poll_interval_seconds", 2.0)
-                if pubtator3_options
-                else 2.0,
-                poll_backoff=pubtator3_options.get("poll_backoff", 1.5) if pubtator3_options else 1.5,
-                max_poll_interval_seconds=(
-                    pubtator3_options.get("max_poll_interval_seconds", 15.0)
+        try:
+            if annotator == "bern2":
+                results[annotator] = annotate_with_bern2(
+                    document,
+                    request_fn=bern2_request_fn,
+                )
+            elif annotator == "flair":
+                results[annotator] = annotate_with_flair(
+                    document,
+                    spans=flair_spans,
+                    tagger=flair_tagger,
+                )
+            elif annotator == "pubtator3":
+                results[annotator] = annotate_with_pubtator3(
+                    document,
+                    request_fn=pubtator3_request_fn,
+                    endpoint=pubtator3_options.get("endpoint")
                     if pubtator3_options
-                    else 15.0
-                ),
-                max_poll_attempts=pubtator3_options.get("max_poll_attempts", 15)
-                if pubtator3_options
-                else 15,
-            )
-        else:
-            raise ValueError(f"Unsupported annotator: {annotator}")
+                    else None,
+                    timeout=pubtator3_options.get("timeout", 60)
+                    if pubtator3_options
+                    else 60,
+                    format=pubtator3_options.get("format", "biocjson")
+                    if pubtator3_options
+                    else "biocjson",
+                    mode=pubtator3_options.get("mode", "auto")
+                    if pubtator3_options
+                    else "auto",
+                    bioconcept=pubtator3_options.get("bioconcept", "All")
+                    if pubtator3_options
+                    else "All",
+                    poll_interval_seconds=pubtator3_options.get(
+                        "poll_interval_seconds",
+                        2.0,
+                    )
+                    if pubtator3_options
+                    else 2.0,
+                    poll_backoff=pubtator3_options.get("poll_backoff", 1.5)
+                    if pubtator3_options
+                    else 1.5,
+                    max_poll_interval_seconds=(
+                        pubtator3_options.get(
+                            "max_poll_interval_seconds",
+                            15.0,
+                        )
+                        if pubtator3_options
+                        else 15.0
+                    ),
+                    max_poll_attempts=pubtator3_options.get("max_poll_attempts", 15)
+                    if pubtator3_options
+                    else 15,
+                )
+            else:
+                raise ValueError(f"Unsupported annotator: {annotator}")
+        except Exception as exc:
+            print(f"{annotator} unavailable: {exc}")
+            results[annotator] = []
 
     return results
-
 
 def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation]:
     annotations: list[Annotation] = []

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import csv
 import json
 from pathlib import Path
@@ -180,14 +181,15 @@ def write_keywords_tsv(payload: dict[str, Any], output_path: Path) -> None:
             if isinstance(item, dict)
         ]
 
+        first_mention = _first_mention(keyword)
         rows.append(
             {
                 "document_id": document_id,
                 "pmid": document.get("pmid"),
                 "title": document.get("title"),
                 "keyword": keyword.get("keyword"),
-                "start": keyword.get("start"),
-                "end": keyword.get("end"),
+                "start": first_mention.get("start"),
+                "end": first_mention.get("end"),
                 "annotation_count": keyword.get("annotation_count"),
                 "annotator_count": keyword.get("annotator_count"),
                 "labels": _join_values(keyword.get("labels")),
@@ -237,26 +239,29 @@ def write_keyword_annotator_evidence_tsv(
         document_id = str(keyword.get("document_id") or "")
         document = documents.get(document_id, {})
 
-        for item in keyword.get("annotators", []):
-            if not isinstance(item, dict):
+        for mention in keyword.get("mentions", []):
+            if not isinstance(mention, dict):
                 continue
+            for item in mention.get("annotators", []):
+                if not isinstance(item, dict):
+                    continue
 
-            rows.append(
-                {
-                    "document_id": document_id,
-                    "pmid": document.get("pmid"),
-                    "title": document.get("title"),
-                    "keyword": keyword.get("keyword"),
-                    "start": keyword.get("start"),
-                    "end": keyword.get("end"),
-                    "source": item.get("source"),
-                    "label": item.get("label"),
-                    "annotation_id": item.get("annotation_id"),
-                    "canonical_id": item.get("canonical_id"),
-                    "canonical_name": item.get("canonical_name"),
-                    "confidence": item.get("confidence"),
-                }
-            )
+                rows.append(
+                    {
+                        "document_id": document_id,
+                        "pmid": document.get("pmid"),
+                        "title": document.get("title"),
+                        "keyword": keyword.get("keyword"),
+                        "start": mention.get("start"),
+                        "end": mention.get("end"),
+                        "source": item.get("source"),
+                        "label": item.get("label"),
+                        "annotation_id": item.get("annotation_id"),
+                        "canonical_id": _join_values(item.get("canonical_id")),
+                        "canonical_name": item.get("canonical_name"),
+                        "confidence": item.get("confidence"),
+                    }
+                )
 
     _write_tsv(
         output_path,
@@ -300,7 +305,7 @@ def write_annotations_tsv(payload: dict[str, Any], output_path: Path) -> None:
                 "end": annotation.get("end"),
                 "entity_type": annotation.get("entity_type"),
                 "annotation_id": annotation.get("annotation_id"),
-                "canonical_id": annotation.get("canonical_id"),
+                "canonical_id": _join_values(annotation.get("canonical_id")),
                 "canonical_name": annotation.get("canonical_name"),
                 "confidence": annotation.get("confidence"),
             }
@@ -733,8 +738,17 @@ def _documents_by_id(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return documents
 
 
+def _first_mention(keyword: dict[str, Any]) -> dict[str, Any]:
+    mentions = keyword.get("mentions")
+    if isinstance(mentions, list):
+        for mention in mentions:
+            if isinstance(mention, dict):
+                return mention
+    return {}
+
+
 def _normalize_scalar_id(value: object) -> object:
-    flattened = list(_flatten_values(value))
+    flattened = [_normalize_identifier_text(item) for item in _flatten_values(value)]
     if not flattened:
         return None
     if len(flattened) == 1:
@@ -750,19 +764,41 @@ def _flatten_values(values: object) -> list[object]:
         for value in values:
             flattened.extend(_flatten_values(value))
         return flattened
+    if isinstance(values, str):
+        parsed = _parse_stringified_list(values)
+        if parsed is not None:
+            return _flatten_values(parsed)
     return [values]
+
+
+def _normalize_identifier_text(value: object) -> object:
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    if stripped.lower().startswith("mesh:"):
+        return f"MESH:{stripped.split(':', 1)[1]}"
+    return stripped
+
+
+def _parse_stringified_list(value: str) -> object | None:
+    stripped = value.strip()
+    if not stripped.startswith("[") or not stripped.endswith("]"):
+        return None
+    try:
+        parsed = ast.literal_eval(stripped)
+    except (SyntaxError, ValueError):
+        return None
+    return parsed if isinstance(parsed, list | tuple | set) else None
 
 
 def _join_values(values: object) -> str:
     if values is None:
         return ""
-    if isinstance(values, list | tuple | set):
-        return "|".join(
-            str(value)
-            for value in _flatten_values(values)
-            if value is not None
-        )
-    return str(values)
+    return "|".join(
+        str(_normalize_identifier_text(value))
+        for value in _flatten_values(values)
+        if value is not None
+    )
 
 
 def _write_tsv(

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -65,7 +65,7 @@ def build_pipeline_output(
     flair_tagger = None
     if "flair" in enabled_annotators and flair_spans_by_document is None:
         try:
-            flair_tagger = _load_flair_tagger(flair_options["model"])
+            flair_tagger = _load_flair_tagger(flair_options["model"] or "hunflair2")
         except Exception as exc:
             print(f"flair unavailable: {exc}")
     document_annotations: list[dict[str, Any]] = []
@@ -75,8 +75,11 @@ def build_pipeline_output(
         "document_count": len(documents),
         "annotation_count": 0,
     }
+
+    all_statuses: list[dict[str, Any]] = []
+
     for document in documents:
-        results = run_selected_annotators(
+        results, statuses = run_selected_annotators_with_status(
             document,
             enabled_annotators,
             bern2_request_fn=bern2_request_fn,
@@ -90,6 +93,11 @@ def build_pipeline_output(
             ),
             flair_tagger=flair_tagger,
         )
+<<<<<<< HEAD
+=======
+        all_statuses.extend(statuses)
+
+>>>>>>> 51a18c5 (Fix keyword output annotator summaries)
         annotations = flatten_annotations(results)
         annotations = filter_annotations_by_type(annotations, config.entity_types)
         annotation_summary["annotation_count"] += len(annotations)
@@ -98,6 +106,7 @@ def build_pipeline_output(
                 {
                     "document_id": document.document_id,
                     "sources": sorted(results),
+                    "annotators": statuses,
                     "annotation_count": len(annotations),
                     "annotations": [annotation.to_dict() for annotation in annotations],
                 }
@@ -123,6 +132,10 @@ def build_pipeline_output(
         "entity_types": config.entity_types,
         "documents": corpus_documents,
         "annotation_summary": annotation_summary,
+        "annotator_summary": _build_annotator_summary(
+            enabled_annotators,
+            all_statuses,
+        ),
         "document_annotations": document_annotations,
         "annotations": annotations_output,
     }
@@ -323,8 +336,36 @@ def run_selected_annotators(
     pubtator3_options: dict[str, Any] | None = None,
     flair_spans: list[Any] | None = None,
     flair_tagger: Any = None,
+    flair_options: dict[str, Any] | None = None,
 ) -> dict[str, list[Annotation]]:
+    results, _ = run_selected_annotators_with_status(
+        document,
+        annotators,
+        bern2_request_fn=bern2_request_fn,
+        pubtator3_request_fn=pubtator3_request_fn,
+        bern2_options=bern2_options,
+        pubtator3_options=pubtator3_options,
+        flair_spans=flair_spans,
+        flair_tagger=flair_tagger,
+        flair_options=flair_options,
+    )
+    return results
+
+
+def run_selected_annotators_with_status(
+    document: Document,
+    annotators: list[str],
+    *,
+    bern2_request_fn: Callable[[Document], Any] | None = None,
+    pubtator3_request_fn: Callable[[Document], Any] | None = None,
+    bern2_options: dict[str, Any] | None = None,
+    pubtator3_options: dict[str, Any] | None = None,
+    flair_spans: list[Any] | None = None,
+    flair_tagger: Any = None,
+    flair_options: dict[str, Any] | None = None,
+) -> tuple[dict[str, list[Annotation]], list[dict[str, Any]]]:
     results: dict[str, list[Annotation]] = {}
+    statuses: list[dict[str, Any]] = []
 
     for annotator in annotators:
         try:
@@ -343,6 +384,7 @@ def run_selected_annotators(
                     document,
                     spans=flair_spans,
                     tagger=flair_tagger,
+                    model=flair_options.get("model") if flair_options else None,
                 )
             elif annotator == "pubtator3":
                 results[annotator] = annotate_with_pubtator3(
@@ -389,8 +431,33 @@ def run_selected_annotators(
         except Exception as exc:
             print(f"{annotator} unavailable: {exc}")
             results[annotator] = []
+            statuses.append(
+                {
+                    "name": annotator,
+                    "status": "failed",
+                    "annotation_count": 0,
+                    "reason": str(exc),
+                }
+            )
+            continue
 
-    return results
+        annotation_count = len(results[annotator])
+        if annotation_count:
+            status = "produced_annotations"
+            reason = None
+        else:
+            status = "no_annotations"
+            reason = _no_annotations_reason(annotator)
+        statuses.append(
+            {
+                "name": annotator,
+                "status": status,
+                "annotation_count": annotation_count,
+                "reason": reason,
+            }
+        )
+
+    return results, statuses
 
 
 def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation]:
@@ -400,7 +467,135 @@ def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation
     return annotations
 
 
+<<<<<<< HEAD
 def filter_annotations_by_type(annotations: list[Annotation], entity_types: list[str]) -> list[Annotation]:
+=======
+def build_keyword_annotations(
+    document_id: str,
+    annotations: list[Annotation],
+) -> list[dict[str, Any]]:
+    groups: dict[tuple[str, str], dict[str, Any]] = {}
+
+    for annotation in annotations:
+        keyword = annotation.span_text.strip()
+        if not keyword:
+            continue
+
+        normalized = keyword.casefold()
+        key = (document_id, normalized)
+
+        if key not in groups:
+            groups[key] = {
+                "document_id": document_id,
+                "keyword": keyword,
+                "normalized_keyword": normalized,
+                "variants": [],
+                "mention_count": 0,
+                "annotation_count": 0,
+                "annotator_count": 0,
+                "labels": [],
+                "canonical_ids": [],
+                "mentions": [],
+                "annotators": [],
+            }
+
+        group = groups[key]
+        group["annotation_count"] += 1
+        if keyword not in group["variants"]:
+            group["variants"].append(keyword)
+        group["annotators"].append(
+            {
+                "source": annotation.source,
+                "label": annotation.entity_type,
+                "annotation_id": annotation.annotation_id,
+                "canonical_id": _normalize_scalar_id(annotation.canonical_id),
+                "canonical_name": annotation.canonical_name,
+                "confidence": annotation.confidence,
+            }
+        )
+
+        mention_key = (annotation.start, annotation.end)
+        mention = next(
+            (
+                item
+                for item in group["mentions"]
+                if (item["start"], item["end"]) == mention_key
+            ),
+            None,
+        )
+        if mention is None:
+            mention = {
+                "text": keyword,
+                "start": annotation.start,
+                "end": annotation.end,
+                "annotation_count": 0,
+                "annotator_count": 0,
+                "annotators": [],
+            }
+            group["mentions"].append(mention)
+        mention["annotation_count"] += 1
+        mention["annotators"].append(
+            {
+                "source": annotation.source,
+                "label": annotation.entity_type,
+                "annotation_id": annotation.annotation_id,
+                "canonical_id": _normalize_scalar_id(annotation.canonical_id),
+                "canonical_name": annotation.canonical_name,
+                "confidence": annotation.confidence,
+            }
+        )
+
+    for group in groups.values():
+        group["variants"] = sorted(group["variants"])
+        group["mention_count"] = len(group["mentions"])
+        group["mentions"] = [_finalize_mention(item) for item in group["mentions"]]
+        group["mentions"] = sorted(
+            group["mentions"],
+            key=lambda item: (
+                item["start"] is None,
+                item["start"] if item["start"] is not None else -1,
+                item["end"] is None,
+                item["end"] if item["end"] is not None else -1,
+                item["text"].casefold(),
+            ),
+        )
+        group["annotators"] = _summarize_keyword_annotators(group["annotators"])
+        group["annotator_count"] = len(group["annotators"])
+        group["labels"] = sorted(
+            {
+                item["label"]
+                for mention in group["mentions"]
+                for item in mention["annotators"]
+                if item["label"] is not None
+            }
+        )
+        group["canonical_ids"] = sorted(
+            {
+                canonical_id
+                for item in group["annotators"]
+                for canonical_id in _flatten_values(item["canonical_ids"])
+                if canonical_id
+            }
+        )
+
+    return sorted(
+        groups.values(),
+        key=lambda item: (
+            item["document_id"],
+            item["mentions"][0]["start"] is None,
+            item["mentions"][0]["start"] if item["mentions"][0]["start"] is not None else -1,
+            item["mentions"][0]["end"] is None,
+            item["mentions"][0]["end"] if item["mentions"][0]["end"] is not None else -1,
+            item["keyword"].casefold(),
+        ),
+    )
+
+
+def filter_annotations_by_type(
+    annotations: list[Annotation],
+    entity_types: list[str],
+) -> list[Annotation]:
+>>>>>>> 51a18c5 (Fix keyword output annotator summaries)
     if not entity_types:
         return annotations
     allowed = set(entity_types)
@@ -420,6 +615,113 @@ def document_to_dict(document: Document) -> dict[str, Any]:
     }
 
 
+def _build_annotator_summary(
+    configured: list[str],
+    statuses: list[dict[str, Any]],
+) -> dict[str, Any]:
+    produced = sorted(
+        {
+            str(status["name"])
+            for status in statuses
+            if status.get("status") == "produced_annotations"
+        }
+    )
+    failed = sorted(
+        {
+            str(status["name"])
+            for status in statuses
+            if status.get("status") == "failed"
+        }
+    )
+    not_produced = [
+        name
+        for name in configured
+        if name not in produced and name not in failed
+    ]
+    return {
+        "configured": configured,
+        "produced": produced,
+        "not_produced": not_produced,
+        "failed": failed,
+        "annotators": statuses,
+    }
+
+
+def _no_annotations_reason(annotator: str) -> str:
+    if annotator == "bern2":
+        return (
+            "No annotations returned. Verify the Bern2 service is reachable "
+            "and returned entities for this document."
+        )
+    if annotator == "flair":
+        return (
+            "No annotations returned. The Flair model may be unavailable/not "
+            "cached, or it found no entities."
+        )
+    if annotator == "pubtator3":
+        return (
+            "No annotations returned. Verify PubTator3 is reachable and "
+            "returned entities for this document."
+        )
+    return "No annotations returned."
+
+
+def _finalize_mention(mention: dict[str, Any]) -> dict[str, Any]:
+    mention["annotators"] = sorted(
+        mention["annotators"],
+        key=lambda item: (
+            item["source"],
+            item["label"],
+            item["annotation_id"],
+        ),
+    )
+    mention["annotator_count"] = len(
+        {
+            item["source"]
+            for item in mention["annotators"]
+        }
+    )
+    return mention
+
+
+def _summarize_keyword_annotators(
+    annotators: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    by_source: dict[str, dict[str, Any]] = {}
+    for item in annotators:
+        source = str(item["source"])
+        summary = by_source.setdefault(
+            source,
+            {
+                "source": source,
+                "annotation_count": 0,
+                "labels": [],
+                "canonical_ids": [],
+                "canonical_names": [],
+            },
+        )
+        summary["annotation_count"] += 1
+        if item.get("label") is not None:
+            summary["labels"].append(item["label"])
+        if item.get("canonical_id") is not None:
+            summary["canonical_ids"].append(item["canonical_id"])
+        if item.get("canonical_name") is not None:
+            summary["canonical_names"].append(item["canonical_name"])
+
+    for summary in by_source.values():
+        summary["labels"] = sorted(set(summary["labels"]))
+        summary["canonical_ids"] = sorted(
+            {
+                value
+                for value in _flatten_values(summary["canonical_ids"])
+                if value is not None
+            }
+        )
+        summary["canonical_names"] = sorted(set(summary["canonical_names"]))
+
+    return sorted(by_source.values(), key=lambda item: item["source"])
+
+
 def _documents_by_id(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
     documents: dict[str, dict[str, Any]] = {}
     for document in payload.get("documents", []):
@@ -431,11 +733,35 @@ def _documents_by_id(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return documents
 
 
+def _normalize_scalar_id(value: object) -> object:
+    flattened = list(_flatten_values(value))
+    if not flattened:
+        return None
+    if len(flattened) == 1:
+        return flattened[0]
+    return flattened
+
+
+def _flatten_values(values: object) -> list[object]:
+    if values is None:
+        return []
+    if isinstance(values, list | tuple | set):
+        flattened: list[object] = []
+        for value in values:
+            flattened.extend(_flatten_values(value))
+        return flattened
+    return [values]
+
+
 def _join_values(values: object) -> str:
     if values is None:
         return ""
     if isinstance(values, list | tuple | set):
-        return "|".join(str(value) for value in values if value is not None)
+        return "|".join(
+            str(value)
+            for value in _flatten_values(values)
+            if value is not None
+        )
     return str(values)
 
 
@@ -464,7 +790,6 @@ def _validate_annotators(annotators: list[str]) -> None:
 def _read_bern2_options(settings: dict[str, object]) -> dict[str, Any]:
     endpoint = settings.get("endpoint")
     base_url = settings.get("base_url")
-    timeout = settings.get("timeout")
 
     cleaned_endpoint = None
     if isinstance(endpoint, str) and endpoint.strip():
@@ -474,18 +799,19 @@ def _read_bern2_options(settings: dict[str, object]) -> dict[str, Any]:
 
     return {
         "endpoint": cleaned_endpoint,
-        "timeout": (
-            int(timeout)
-            if isinstance(timeout, int) and timeout > 0
-            else 30
-        ),
     }
 
 
 def _read_flair_options(settings: dict[str, object]) -> dict[str, Any]:
     model = settings.get("model")
     return {
+<<<<<<< HEAD
         "model": model.strip() if isinstance(model, str) and model.strip() else "hunflair2",
+=======
+        "model": model.strip()
+        if isinstance(model, str) and model.strip()
+        else None,
+>>>>>>> 51a18c5 (Fix keyword output annotator summaries)
     }
 
 

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import csv
 import json
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
@@ -463,6 +464,10 @@ def run_selected_annotators_with_status(
                     max_poll_attempts=pubtator3_options.get("max_poll_attempts", 15)
                     if pubtator3_options
                     else 15,
+                    max_poll_seconds=pubtator3_options.get("max_poll_seconds", 180.0)
+                    if pubtator3_options
+                    else 180.0,
+                    progress_callback=_pubtator3_progress,
                 )
             else:
                 raise ValueError(f"Unsupported annotator: {annotator}")
@@ -700,6 +705,21 @@ def _no_annotations_reason(annotator: str) -> str:
     return "No annotations returned."
 
 
+def _pubtator3_progress(
+    session_id: str,
+    attempt: int,
+    max_attempts: int,
+    sleep_seconds: float,
+) -> None:
+    print(
+        "pubtator3 pending: "
+        f"session={session_id} attempt={attempt}/{max_attempts}; "
+        f"sleeping {sleep_seconds:.1f}s",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
 def _finalize_mention(mention: dict[str, Any]) -> dict[str, Any]:
     mention["annotators"] = sorted(
         mention["annotators"],
@@ -892,6 +912,7 @@ def _read_pubtator3_options(settings: dict[str, object]) -> dict[str, Any]:
     poll_backoff = settings.get("poll_backoff")
     max_poll_interval_seconds = settings.get("max_poll_interval_seconds")
     max_poll_attempts = settings.get("max_poll_attempts")
+    max_poll_seconds = settings.get("max_poll_seconds")
 
     cleaned_mode = mode.strip().lower() if isinstance(mode, str) and mode.strip() else "auto"
     if cleaned_mode not in {"auto", "publication_only", "text_only"}:
@@ -925,5 +946,10 @@ def _read_pubtator3_options(settings: dict[str, object]) -> dict[str, Any]:
             int(max_poll_attempts)
             if isinstance(max_poll_attempts, int) and max_poll_attempts > 0
             else 15
+        ),
+        "max_poll_seconds": (
+            float(max_poll_seconds)
+            if isinstance(max_poll_seconds, (int, float)) and float(max_poll_seconds) > 0
+            else 180.0
         ),
     }

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -1,115 +1,273 @@
 from __future__ import annotations
 
-from functools import lru_cache
-from typing import Any, Callable, Iterable
+import json
+from pathlib import Path
+from typing import Any, Callable
 
-from bio_annotation.entity_proposal._shared import make_annotation
+from bio_annotation.annotators.bern2 import annotate_with_bern2
+from bio_annotation.annotators.flair import annotate_with_flair
+from bio_annotation.annotators.pubtator3 import annotate_with_pubtator3
+from bio_annotation.pipeline_config import PipelineConfig, load_pipeline_config
+from bio_annotation.preprocessing.document_loader import (
+    load_documents_from_config,
+    resolve_input_description,
+    summarize_ingestion,
+)
 from bio_annotation.schemas.document import Document
 from bio_annotation.schemas.entity import Annotation
 
-
-def _extract_flair_label(span: Any) -> tuple[Any, Any]:
-    if hasattr(span, "get_label"):
-        label = span.get_label("ner")
-        return getattr(label, "value", None), getattr(label, "score", None)
-
-    labels = getattr(span, "labels", None)
-    if labels:
-        first = labels[0]
-        return getattr(first, "value", None), getattr(first, "score", None)
-
-    return getattr(span, "tag", None), getattr(span, "score", None)
+SUPPORTED_ANNOTATORS = {"bern2", "flair", "pubtator3"}
 
 
-def parse_flair_spans(document: Document, spans: Iterable[Any]) -> list[Annotation]:
-    annotations: list[Annotation] = []
-    for span in spans:
-        label, score = _extract_flair_label(span)
-        text = getattr(span, "text", None)
-        if text is None and hasattr(span, "to_original_text"):
-            text = span.to_original_text()
-        if not text:
-            continue
-
-        annotations.append(
-            make_annotation(
-                document=document,
-                source="flair",
-                span_text=text,
-                entity_type=label,
-                start=getattr(span, "start_position", None),
-                end=getattr(span, "end_position", None),
-                confidence=score,
-            )
-        )
-
-    return annotations
-
-
-@lru_cache(maxsize=4)
-def _load_flair_tagger(model: str) -> Any:
-    from flair.models import SequenceTagger
-
-    return SequenceTagger.load(model)
-
-
-def parse_flair_labels(document: Document, labels: Iterable[Any]) -> list[Annotation]:
-    annotations: list[Annotation] = []
-    for label in labels:
-        span = getattr(label, "data_point", None)
-        if span is None:
-            continue
-        text = getattr(span, "text", None)
-        if not text:
-            continue
-
-        annotations.append(
-            make_annotation(
-                document=document,
-                source="flair",
-                span_text=text,
-                entity_type=getattr(label, "value", None),
-                start=getattr(span, "start_position", None),
-                end=getattr(span, "end_position", None),
-                confidence=getattr(label, "score", None),
-            )
-        )
-
-    return annotations
-
-
-def annotate_with_flair(
-    document: Document,
+def run_pipeline_from_config(
+    config_path: Path,
     *,
-    spans: Iterable[Any] | None = None,
-    tagger: Any = None,
-    model: str | None = None,
-    sentence_factory: Callable[[str], Any] | None = None,
-    tagger_loader: Callable[[str], Any] | None = None,
-) -> list[Annotation]:
-    if spans is not None:
-        return parse_flair_spans(document, spans)
+    orchestrator_factory: Callable[[], Any] | None = None,
+    bern2_request_fn: Callable[[Document], Any] | None = None,
+    pubtator3_request_fn: Callable[[Document], Any] | None = None,
+    flair_spans_by_document: dict[str, list[Any]] | None = None,
+) -> dict[str, Any]:
+    config = load_pipeline_config(config_path)
+    documents = load_documents_from_config(
+        config,
+        orchestrator_factory=orchestrator_factory,
+    )
+    payload = build_pipeline_output(
+        documents,
+        config,
+        bern2_request_fn=bern2_request_fn,
+        pubtator3_request_fn=pubtator3_request_fn,
+        flair_spans_by_document=flair_spans_by_document,
+    )
+    if config.output_path is not None:
+        write_pipeline_output(payload, config.output_path)
+    return payload
 
-    if tagger is None and model:
-        loader = tagger_loader or _load_flair_tagger
-        tagger = loader(model)
 
-    if tagger is not None:
-        if sentence_factory is None:
-            try:
-                from flair.data import Sentence
-            except ImportError:
-                return []
-            sentence = Sentence(document.text)
+def build_pipeline_output(
+    documents: list[Document],
+    config: PipelineConfig,
+    *,
+    bern2_request_fn: Callable[[Document], Any] | None = None,
+    pubtator3_request_fn: Callable[[Document], Any] | None = None,
+    flair_spans_by_document: dict[str, list[Any]] | None = None,
+) -> dict[str, Any]:
+    enabled_annotators = list(config.annotators)
+    annotator_settings = dict(config.annotator_settings)
+    _validate_annotators(enabled_annotators)
+    input_description = resolve_input_description(config)
+    corpus_documents = [document_to_dict(document) for document in documents]
+    pubtator3_options = _read_pubtator3_options(annotator_settings.get("pubtator3", {}))
+    flair_options = _read_flair_options(annotator_settings.get("flair", {}))
+
+    flair_tagger = None
+    if (
+        "flair" in enabled_annotators
+        and flair_spans_by_document is None
+    ):
+        flair_tagger = _load_flair_tagger(flair_options["model"])
+
+    document_annotations: list[dict[str, Any]] = []
+    annotations_output: list[dict[str, Any]] = []
+    annotation_summary = {
+        "annotators_enabled": enabled_annotators,
+        "document_count": len(documents),
+        "annotation_count": 0,
+    }
+    for document in documents:
+        results = run_selected_annotators(
+            document,
+            enabled_annotators,
+            bern2_request_fn=bern2_request_fn,
+            pubtator3_request_fn=pubtator3_request_fn,
+            pubtator3_options=pubtator3_options,
+            flair_spans=(
+                flair_spans_by_document.get(document.document_id)
+                if flair_spans_by_document is not None
+                else None
+            ),
+            flair_tagger=flair_tagger,
+        )
+        annotations = flatten_annotations(results)
+        annotations = filter_annotations_by_type(annotations, config.entity_types)
+        annotation_summary["annotation_count"] += len(annotations)
+        if enabled_annotators:
+            document_annotations.append(
+                {
+                    "document_id": document.document_id,
+                    "sources": sorted(results),
+                    "annotation_count": len(annotations),
+                    "annotations": [annotation.to_dict() for annotation in annotations],
+                }
+            )
+        annotations_output.extend(
+            {
+                "document_id": document.document_id,
+                **annotation.to_dict(),
+            }
+            for annotation in annotations
+        )
+
+    return {
+        "stage": "corpus",
+        "input": input_description,
+        "pipeline": {
+            "mode": "ingestion_only" if not enabled_annotators else "ingestion_and_annotation",
+            "annotators_enabled": enabled_annotators,
+            "annotator_settings": {name: annotator_settings.get(name, {}) for name in enabled_annotators},
+        },
+        "document_count": len(corpus_documents),
+        "corpus_summary": summarize_ingestion(documents),
+        "entity_types": config.entity_types,
+        "documents": corpus_documents,
+        "annotation_summary": annotation_summary,
+        "document_annotations": document_annotations,
+        "annotations": annotations_output,
+    }
+
+
+def write_pipeline_output(payload: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def run_selected_annotators(
+    document: Document,
+    annotators: list[str],
+    *,
+    bern2_request_fn: Callable[[Document], Any] | None = None,
+    pubtator3_request_fn: Callable[[Document], Any] | None = None,
+    pubtator3_options: dict[str, Any] | None = None,
+    flair_spans: list[Any] | None = None,
+    flair_tagger: Any = None,
+) -> dict[str, list[Annotation]]:
+    results: dict[str, list[Annotation]] = {}
+
+    for annotator in annotators:
+        if annotator == "bern2":
+            results[annotator] = annotate_with_bern2(document, request_fn=bern2_request_fn)
+        elif annotator == "flair":
+            results[annotator] = annotate_with_flair(
+                document,
+                spans=flair_spans,
+                tagger=flair_tagger,
+            )
+        elif annotator == "pubtator3":
+            results[annotator] = annotate_with_pubtator3(
+                document,
+                request_fn=pubtator3_request_fn,
+                endpoint=pubtator3_options.get("endpoint") if pubtator3_options else None,
+                timeout=pubtator3_options.get("timeout", 60) if pubtator3_options else 60,
+                format=pubtator3_options.get("format", "biocjson") if pubtator3_options else "biocjson",
+                mode=pubtator3_options.get("mode", "auto") if pubtator3_options else "auto",
+                bioconcept=pubtator3_options.get("bioconcept", "All") if pubtator3_options else "All",
+                poll_interval_seconds=pubtator3_options.get("poll_interval_seconds", 2.0)
+                if pubtator3_options
+                else 2.0,
+                poll_backoff=pubtator3_options.get("poll_backoff", 1.5) if pubtator3_options else 1.5,
+                max_poll_interval_seconds=(
+                    pubtator3_options.get("max_poll_interval_seconds", 15.0)
+                    if pubtator3_options
+                    else 15.0
+                ),
+                max_poll_attempts=pubtator3_options.get("max_poll_attempts", 15)
+                if pubtator3_options
+                else 15,
+            )
         else:
-            sentence = sentence_factory(document.text)
+            raise ValueError(f"Unsupported annotator: {annotator}")
 
-        tagger.predict(sentence)
+    return results
 
-        if hasattr(sentence, "get_labels"):
-            return parse_flair_labels(document, sentence.get_labels())
-        if hasattr(sentence, "get_spans"):
-            return parse_flair_spans(document, sentence.get_spans("ner"))
-        return []
 
-    return []
+def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation]:
+    annotations: list[Annotation] = []
+    for source in ("bern2", "flair", "pubtator3"):
+        annotations.extend(results.get(source, []))
+    return annotations
+
+
+def filter_annotations_by_type(annotations: list[Annotation], entity_types: list[str]) -> list[Annotation]:
+    if not entity_types:
+        return annotations
+    allowed = set(entity_types)
+    return [annotation for annotation in annotations if annotation.entity_type in allowed]
+
+
+def document_to_dict(document: Document) -> dict[str, Any]:
+    return {
+        "document_id": document.document_id,
+        "pmid": document.pmid,
+        "title": document.title,
+        "abstract": document.abstract,
+        "full_text": document.full_text,
+        "source": document.source,
+        "year": document.year,
+        "metadata": document.metadata,
+    }
+
+
+def _validate_annotators(annotators: list[str]) -> None:
+    unsupported = [annotator for annotator in annotators if annotator not in SUPPORTED_ANNOTATORS]
+    if unsupported:
+        raise ValueError(f"Unsupported annotators requested: {', '.join(unsupported)}")
+
+
+def _read_flair_options(settings: dict[str, object]) -> dict[str, Any]:
+    model = settings.get("model")
+    return {
+        "model": model.strip() if isinstance(model, str) and model.strip() else "hunflair2",
+    }
+
+
+def _load_flair_tagger(model: str) -> Any:
+    from flair.nn import Classifier
+
+    return Classifier.load(model)
+
+
+def _read_pubtator3_options(settings: dict[str, object]) -> dict[str, Any]:
+    endpoint = settings.get("endpoint")
+    timeout = settings.get("timeout")
+    export_format = settings.get("format")
+    mode = settings.get("mode")
+    bioconcept = settings.get("bioconcept")
+    poll_interval_seconds = settings.get("poll_interval_seconds")
+    poll_backoff = settings.get("poll_backoff")
+    max_poll_interval_seconds = settings.get("max_poll_interval_seconds")
+    max_poll_attempts = settings.get("max_poll_attempts")
+
+    cleaned_mode = mode.strip().lower() if isinstance(mode, str) and mode.strip() else "auto"
+    if cleaned_mode not in {"auto", "publication_only", "text_only"}:
+        raise ValueError(
+            "annotators.pubtator3.mode must be one of: "
+            "'auto', 'publication_only', 'text_only'."
+        )
+
+    return {
+        "endpoint": endpoint if isinstance(endpoint, str) and endpoint.strip() else None,
+        "timeout": timeout if isinstance(timeout, int) and timeout > 0 else 60,
+        "format": export_format if isinstance(export_format, str) and export_format.strip() else "biocjson",
+        "mode": cleaned_mode,
+        "bioconcept": bioconcept if isinstance(bioconcept, str) and bioconcept.strip() else "All",
+        "poll_interval_seconds": (
+            float(poll_interval_seconds)
+            if isinstance(poll_interval_seconds, (int, float)) and poll_interval_seconds > 0
+            else 2.0
+        ),
+        "poll_backoff": (
+            float(poll_backoff)
+            if isinstance(poll_backoff, (int, float)) and float(poll_backoff) >= 1.0
+            else 1.5
+        ),
+        "max_poll_interval_seconds": (
+            float(max_poll_interval_seconds)
+            if isinstance(max_poll_interval_seconds, (int, float)) and float(max_poll_interval_seconds) > 0
+            else 15.0
+        ),
+        "max_poll_attempts": (
+            int(max_poll_attempts)
+            if isinstance(max_poll_attempts, int) and max_poll_attempts > 0
+            else 15
+        ),
+    }

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -250,6 +250,24 @@ def _load_flair_tagger(model: str) -> Any:
     return Classifier.load(model)
 
 
+def _read_bern2_options(settings: dict[str, object]) -> dict[str, Any]:
+    base_url = settings.get("base_url")
+    timeout = settings.get("timeout")
+
+    return {
+        "base_url": (
+            base_url.strip()
+            if isinstance(base_url, str) and base_url.strip()
+            else "http://127.0.0.1:8888"
+        ),
+        "timeout": (
+            int(timeout)
+            if isinstance(timeout, int) and timeout > 0
+            else 60
+        ),
+    }
+
+
 def _read_pubtator3_options(settings: dict[str, object]) -> dict[str, Any]:
     endpoint = settings.get("endpoint")
     timeout = settings.get("timeout")

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -13,6 +13,8 @@ from bio_annotation.annotators.pubtator3 import annotate_with_pubtator3
 from bio_annotation.pipeline_config import PipelineConfig, load_pipeline_config
 from bio_annotation.preprocessing.document_loader import (
     load_documents_from_config,
+    load_documents_from_pmid_file,
+    load_documents_from_pmids,
     resolve_input_description,
     summarize_ingestion,
 )
@@ -26,15 +28,31 @@ def run_pipeline_from_config(
     config_path: Path,
     *,
     orchestrator_factory: Callable[[], Any] | None = None,
+    pmid_fetcher: Callable[[str], dict[str, Any]] | None = None,
     bern2_request_fn: Callable[[Document], Any] | None = None,
     pubtator3_request_fn: Callable[[Document], Any] | None = None,
     flair_spans_by_document: dict[str, list[Any]] | None = None,
 ) -> dict[str, Any]:
     config = load_pipeline_config(config_path)
-    documents = load_documents_from_config(
-        config,
-        orchestrator_factory=orchestrator_factory,
-    )
+    if pmid_fetcher is not None and config.input_mode == "pmids":
+        documents = load_documents_from_pmids(
+            config.pmids,
+            fetcher=pmid_fetcher,
+            enrichment_sources=config.enrichment_sources,
+        )
+    elif pmid_fetcher is not None and config.input_mode == "pmid_file":
+        if config.pmid_file is None:
+            raise ValueError("input.pmid_file must be set when input.mode = 'pmid_file'.")
+        documents = load_documents_from_pmid_file(
+            config.pmid_file,
+            fetcher=pmid_fetcher,
+            enrichment_sources=config.enrichment_sources,
+        )
+    else:
+        documents = load_documents_from_config(
+            config,
+            orchestrator_factory=orchestrator_factory,
+        )
     payload = build_pipeline_output(
         documents,
         config,
@@ -78,10 +96,12 @@ def build_pipeline_output(
             print(f"flair unavailable: {exc}")
     document_annotations: list[dict[str, Any]] = []
     annotations_output: list[dict[str, Any]] = []
+    keyword_output: list[dict[str, Any]] = []
     annotation_summary = {
         "annotators_enabled": enabled_annotators,
         "document_count": len(documents),
         "annotation_count": 0,
+        "keyword_count": 0,
     }
 
     all_statuses: list[dict[str, Any]] = []
@@ -101,14 +121,14 @@ def build_pipeline_output(
             ),
             flair_tagger=flair_tagger,
         )
-<<<<<<< HEAD
-=======
         all_statuses.extend(statuses)
 
->>>>>>> 51a18c5 (Fix keyword output annotator summaries)
         annotations = flatten_annotations(results)
         annotations = filter_annotations_by_type(annotations, config.entity_types)
         annotation_summary["annotation_count"] += len(annotations)
+        document_keywords = build_keyword_annotations(document.document_id, annotations)
+        annotation_summary["keyword_count"] += len(document_keywords)
+        keyword_output.extend(document_keywords)
         if enabled_annotators:
             document_annotations.append(
                 {
@@ -145,6 +165,7 @@ def build_pipeline_output(
             all_statuses,
         ),
         "document_annotations": document_annotations,
+        "keywords": keyword_output,
         "annotations": annotations_output,
     }
 
@@ -484,9 +505,6 @@ def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation
     return annotations
 
 
-<<<<<<< HEAD
-def filter_annotations_by_type(annotations: list[Annotation], entity_types: list[str]) -> list[Annotation]:
-=======
 def build_keyword_annotations(
     document_id: str,
     annotations: list[Annotation],
@@ -612,7 +630,6 @@ def filter_annotations_by_type(
     annotations: list[Annotation],
     entity_types: list[str],
 ) -> list[Annotation]:
->>>>>>> 51a18c5 (Fix keyword output annotator summaries)
     if not entity_types:
         return annotations
     allowed = set(entity_types)
@@ -853,13 +870,9 @@ def _read_bern2_options(settings: dict[str, object]) -> dict[str, Any]:
 def _read_flair_options(settings: dict[str, object]) -> dict[str, Any]:
     model = settings.get("model")
     return {
-<<<<<<< HEAD
-        "model": model.strip() if isinstance(model, str) and model.strip() else "hunflair2",
-=======
         "model": model.strip()
         if isinstance(model, str) and model.strip()
         else None,
->>>>>>> 51a18c5 (Fix keyword output annotator summaries)
     }
 
 

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -105,7 +105,7 @@ def build_pipeline_output(
             document_annotations.append(
                 {
                     "document_id": document.document_id,
-                    "sources": sorted(results),
+                    "sources": sorted({annotation.source for annotation in annotations}),
                     "annotation_count": len(annotations),
                     "keyword_count": len(keyword_annotations),
                     "keywords": keyword_annotations,
@@ -128,9 +128,6 @@ def build_pipeline_output(
         "pipeline": {
             "mode": "ingestion_only" if not enabled_annotators else "ingestion_and_annotation",
             "annotators_enabled": enabled_annotators,
-            "annotator_settings": {
-                name: annotator_settings.get(name, {}) for name in enabled_annotators
-            },
         },
         "document_count": len(corpus_documents),
         "corpus_summary": summarize_ingestion(documents),
@@ -214,71 +211,186 @@ def build_keyword_annotations(
     document_id: str,
     annotations: list[Annotation],
 ) -> list[dict[str, Any]]:
-    groups: dict[tuple[str, str, int | None, int | None], dict[str, Any]] = {}
+    groups: dict[tuple[str, str], dict[str, Any]] = {}
 
     for annotation in annotations:
         keyword = annotation.span_text.strip()
         if not keyword:
             continue
 
-        key = (document_id, keyword.casefold(), annotation.start, annotation.end)
+        normalized_keyword = keyword.casefold()
+        key = (document_id, normalized_keyword)
 
         if key not in groups:
             groups[key] = {
                 "document_id": document_id,
                 "keyword": keyword,
+                "normalized_keyword": normalized_keyword,
+                "variants": [],
+                "mention_count": 0,
+                "annotation_count": 0,
+                "annotator_count": 0,
+                "labels": [],
+                "canonical_ids": [],
+                "canonical_names": [],
+                "annotators": [],
+                "mentions": [],
+            }
+
+        group = groups[key]
+        group["annotation_count"] += 1
+        if keyword not in group["variants"]:
+            group["variants"].append(keyword)
+
+        mention = _find_keyword_mention(group["mentions"], keyword, annotation.start, annotation.end)
+        if mention is None:
+            mention = {
+                "text": keyword,
                 "start": annotation.start,
                 "end": annotation.end,
                 "annotation_count": 0,
                 "annotator_count": 0,
                 "labels": [],
                 "canonical_ids": [],
+                "canonical_names": [],
                 "annotators": [],
             }
+            group["mentions"].append(mention)
 
-        group = groups[key]
-        group["annotation_count"] += 1
+        mention["annotation_count"] += 1
+        evidence = {
+            "source": annotation.source,
+            "label": annotation.entity_type,
+            "annotation_id": annotation.annotation_id,
+            "canonical_id": annotation.canonical_id,
+            "canonical_name": annotation.canonical_name,
+            "confidence": annotation.confidence,
+        }
+        mention["annotators"].append(evidence)
         group["annotators"].append(
             {
                 "source": annotation.source,
                 "label": annotation.entity_type,
-                "annotation_id": annotation.annotation_id,
                 "canonical_id": annotation.canonical_id,
                 "canonical_name": annotation.canonical_name,
+                "annotation_id": annotation.annotation_id,
+                "mention": {
+                    "text": keyword,
+                    "start": annotation.start,
+                    "end": annotation.end,
+                },
                 "confidence": annotation.confidence,
             }
         )
 
     for group in groups.values():
+        group["variants"] = sorted(group["variants"], key=lambda item: (item.casefold(), item))
+        group["mention_count"] = len(group["mentions"])
+        group["mentions"] = sorted(
+            (_finalize_keyword_rollup(mention) for mention in group["mentions"]),
+            key=lambda item: (
+                item["start"] is None,
+                item["start"] if item["start"] is not None else -1,
+                item["end"] is None,
+                item["end"] if item["end"] is not None else -1,
+                item["text"].casefold(),
+            ),
+        )
         group["annotators"] = sorted(
             group["annotators"],
             key=lambda item: (
                 item["source"],
                 item["label"],
+                item["canonical_id"] or "",
                 item["annotation_id"],
             ),
         )
-        group["annotator_count"] = len({item["source"] for item in group["annotators"]})
-        group["labels"] = sorted({item["label"] for item in group["annotators"]})
-        group["canonical_ids"] = sorted(
-            {
-                item["canonical_id"]
-                for item in group["annotators"]
-                if item["canonical_id"] is not None
-            }
-        )
+        _finalize_keyword_rollup(group)
+        group["annotators"] = _build_annotator_summaries(group["annotators"])
 
     return sorted(
         groups.values(),
         key=lambda item: (
             item["document_id"],
-            item["start"] is None,
-            item["start"] if item["start"] is not None else -1,
-            item["end"] is None,
-            item["end"] if item["end"] is not None else -1,
             item["keyword"].casefold(),
         ),
     )
+
+
+def _find_keyword_mention(
+    mentions: list[dict[str, Any]],
+    text: str,
+    start: int | None,
+    end: int | None,
+) -> dict[str, Any] | None:
+    normalized_text = text.casefold()
+    for mention in mentions:
+        if (
+            mention["text"].casefold() == normalized_text
+            and mention["start"] == start
+            and mention["end"] == end
+        ):
+            return mention
+    return None
+
+
+def _finalize_keyword_rollup(group: dict[str, Any]) -> dict[str, Any]:
+    group["annotators"] = sorted(
+        group["annotators"],
+        key=lambda item: (
+            item["source"],
+            item["label"],
+            item["canonical_id"] or "",
+            item["annotation_id"],
+        ),
+    )
+    group["annotator_count"] = len({item["source"] for item in group["annotators"]})
+    group["labels"] = sorted({item["label"] for item in group["annotators"]})
+    group["canonical_ids"] = sorted(
+        {
+            item["canonical_id"]
+            for item in group["annotators"]
+            if item["canonical_id"] is not None
+        }
+    )
+    group["canonical_names"] = sorted(
+        {
+            item["canonical_name"]
+            for item in group["annotators"]
+            if item["canonical_name"] is not None
+        }
+    )
+    return group
+
+
+def _build_annotator_summaries(evidence_items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    summaries: dict[str, dict[str, Any]] = {}
+
+    for evidence in evidence_items:
+        source = evidence["source"]
+        if source not in summaries:
+            summaries[source] = {
+                "source": source,
+                "annotation_count": 0,
+                "labels": [],
+                "canonical_ids": [],
+                "canonical_names": [],
+            }
+
+        summary = summaries[source]
+        summary["annotation_count"] += 1
+        summary["labels"].append(evidence["label"])
+        if evidence["canonical_id"] is not None:
+            summary["canonical_ids"].append(evidence["canonical_id"])
+        if evidence["canonical_name"] is not None:
+            summary["canonical_names"].append(evidence["canonical_name"])
+
+    for summary in summaries.values():
+        summary["labels"] = sorted(set(summary["labels"]))
+        summary["canonical_ids"] = sorted(set(summary["canonical_ids"]))
+        summary["canonical_names"] = sorted(set(summary["canonical_names"]))
+
+    return sorted(summaries.values(), key=lambda item: item["source"])
 
 
 def filter_annotations_by_type(

--- a/tests/test_annotators.py
+++ b/tests/test_annotators.py
@@ -86,6 +86,61 @@ def test_flair_adapter_normalizes_spans() -> None:
     assert annotations[0].confidence == 0.87
 
 
+def test_flair_adapter_loads_configured_model() -> None:
+    document = sample_document()
+    loaded_models: list[str] = []
+
+    class FakeTagger:
+        def predict(self, sentence: object) -> None:
+            return None
+
+    class FakeSentence:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+        def get_spans(self, label_type: str) -> list[FakeSpan]:
+            assert label_type == "ner"
+            return [
+                FakeSpan(
+                    text="PTEN",
+                    start_position=0,
+                    end_position=4,
+                    labels=[FakeLabel(value="gene", score=0.99)],
+                )
+            ]
+
+    def fake_loader(model: str) -> FakeTagger:
+        loaded_models.append(model)
+        return FakeTagger()
+
+    annotations = annotate_with_flair(
+        document,
+        model="hunflair2",
+        sentence_factory=FakeSentence,
+        tagger_loader=fake_loader,
+    )
+
+    assert loaded_models == ["hunflair2"]
+    assert len(annotations) == 1
+    assert annotations[0].source == "flair"
+    assert annotations[0].entity_type == "gene"
+
+
+def test_flair_adapter_returns_empty_when_configured_model_cannot_load() -> None:
+    document = sample_document()
+
+    def broken_loader(model: str) -> object:
+        raise RuntimeError(f"{model} is unavailable")
+
+    annotations = annotate_with_flair(
+        document,
+        model="hunflair2",
+        tagger_loader=broken_loader,
+    )
+
+    assert annotations == []
+
+
 def test_pubtator3_adapter_parses_bioc_json_with_absolute_offsets() -> None:
     document = sample_document()
     response = {
@@ -279,7 +334,10 @@ def test_cli_inspect_config_runs() -> None:
     assert output["input_mode"] == "pmids"
     assert output["pmids"] == ["36403686"]
     assert output["enrichment_sources"] == []
-    assert output["annotators"] == ["pubtator3"]
+    assert output["annotators"] == ["bern2", "flair", "pubtator3"]
+    assert output["annotator_settings"]["bern2"]["runtime"] == "remote_api"
+    assert output["annotator_settings"]["bern2"]["base_url"] == "http://127.0.0.1:8888"
+    assert output["annotator_settings"]["flair"]["model"] == "hunflair2"
     assert output["annotator_settings"]["pubtator3"]["runtime"] == "remote_api"
     assert output["annotator_settings"]["pubtator3"]["format"] == "biocjson"
     assert output["annotator_settings"]["pubtator3"]["endpoint"] == "https://www.ncbi.nlm.nih.gov/research/pubtator3-api"

--- a/tests/test_annotators.py
+++ b/tests/test_annotators.py
@@ -5,6 +5,8 @@ import json
 from io import StringIO
 from contextlib import redirect_stdout
 
+import pytest
+
 from bio_annotation.cli import main
 from bio_annotation.annotators import flatten_annotations, run_all_annotators
 from bio_annotation.annotators.bern2 import annotate_with_bern2
@@ -126,19 +128,18 @@ def test_flair_adapter_loads_configured_model() -> None:
     assert annotations[0].entity_type == "gene"
 
 
-def test_flair_adapter_returns_empty_when_configured_model_cannot_load() -> None:
+def test_flair_adapter_raises_when_configured_model_cannot_load() -> None:
     document = sample_document()
 
     def broken_loader(model: str) -> object:
         raise RuntimeError(f"{model} is unavailable")
 
-    annotations = annotate_with_flair(
-        document,
-        model="hunflair2",
-        tagger_loader=broken_loader,
-    )
-
-    assert annotations == []
+    with pytest.raises(RuntimeError, match="hunflair2 is unavailable"):
+        annotate_with_flair(
+            document,
+            model="hunflair2",
+            tagger_loader=broken_loader,
+        )
 
 
 def test_pubtator3_adapter_parses_bioc_json_with_absolute_offsets() -> None:

--- a/tests/test_ingestion_only_pipeline.py
+++ b/tests/test_ingestion_only_pipeline.py
@@ -112,4 +112,6 @@ def test_run_pipeline_from_config_writes_output_file(tmp_path) -> None:
     payload = run_pipeline_from_config(config_path)
 
     assert payload["document_count"] == 1
-    assert output_path.exists()
+    written = sorted(output_path.parent.glob("*/pipeline.json"))
+    assert len(written) == 1
+    assert payload["output"]["path"] == written[0].as_posix()

--- a/tests/test_pipeline_runner.py
+++ b/tests/test_pipeline_runner.py
@@ -8,8 +8,13 @@ from io import StringIO
 from bio_annotation.cli import main
 from bio_annotation.fetch import FetchOrchestrator
 from bio_annotation.fetch.input import FetchInput, FetchKind
-from bio_annotation.pipeline_runner import _read_pubtator3_options, run_pipeline_from_config
 from bio_annotation.schemas.document import Document
+from bio_annotation.pipeline_runner import (
+    _read_pubtator3_options,
+    build_keyword_annotations,
+    run_pipeline_from_config,
+)
+from bio_annotation.schemas.entity import Annotation
 
 
 @dataclass
@@ -124,9 +129,9 @@ def test_run_pipeline_from_config_with_pmids(tmp_path) -> None:
     assert payload["input"]["mode"] == "pmids"
     assert payload["pipeline"]["mode"] == "ingestion_and_annotation"
     assert payload["pipeline"]["annotators_enabled"] == ["bern2", "pubtator3"]
-    assert payload["pipeline"]["annotator_settings"]["pubtator3"]["timeout"] == 45
     assert payload["documents"][0]["metadata"]["pubmed_record"]["pmcid"] == "PMC1234567"
     assert payload["annotation_summary"]["annotation_count"] == 2
+    assert payload["document_annotations"][0]["sources"] == ["bern2", "pubtator3"]
     assert len(payload["annotations"]) == 2
 
 
@@ -137,7 +142,7 @@ def test_cli_run_config_outputs_payload(tmp_path, monkeypatch) -> None:
             [
                 "[input]",
                 'mode = "text_table"',
-                f'text_file = "{tmp_path / "documents.csv"}"',
+                f'text_file = "{(tmp_path / "documents.csv").as_posix()}"',
                 'format = "csv"',
                 'document_id_column = "document_id"',
                 'title_column = "title"',
@@ -172,7 +177,6 @@ def test_cli_run_config_outputs_payload(tmp_path, monkeypatch) -> None:
             "pipeline": {
                 "mode": "ingestion_and_annotation",
                 "annotators_enabled": ["flair"],
-                "annotator_settings": {"flair": {}},
             },
             "entity_types": ["gene"],
             "documents": [],
@@ -199,7 +203,7 @@ def test_cli_run_config_ingestion_only(tmp_path) -> None:
             [
                 "[input]",
                 'mode = "corpus"',
-                f'corpus_path = "{tmp_path / "documents.json"}"',
+                f'corpus_path = "{(tmp_path / "documents.json").as_posix()}"',
                 "",
                 "[enrichment]",
                 "sources = []",
@@ -254,3 +258,81 @@ def test_read_pubtator3_options_parses_text_mode_settings() -> None:
     assert options["poll_interval_seconds"] == 3.0
     assert options["poll_backoff"] == 2.0
     assert options["max_poll_interval_seconds"] == 12.0
+
+
+def test_build_keyword_annotations_groups_by_keyword_with_mentions_and_evidence() -> None:
+    keywords = build_keyword_annotations(
+        "doc1",
+        [
+            Annotation(
+                annotation_id="pubtator3:1",
+                source="pubtator3",
+                span_text="GBM",
+                start=10,
+                end=13,
+                entity_type="disease",
+                canonical_id="MESH:D005909",
+                canonical_name="Glioblastoma",
+            ),
+            Annotation(
+                annotation_id="bern2:1",
+                source="bern2",
+                span_text="GBM",
+                start=10,
+                end=13,
+                entity_type="disease",
+                canonical_id="BERN:glioblastoma",
+                canonical_name="Glioblastoma",
+                confidence=0.94,
+            ),
+            Annotation(
+                annotation_id="pubtator3:2",
+                source="pubtator3",
+                span_text="gbm",
+                start=40,
+                end=43,
+                entity_type="disease",
+                canonical_id="MESH:D005909",
+                canonical_name="Glioblastoma",
+            ),
+            Annotation(
+                annotation_id="flair:1",
+                source="flair",
+                span_text="tumor",
+                start=55,
+                end=60,
+                entity_type="disease",
+            ),
+        ],
+    )
+
+    assert len(keywords) == 2
+
+    gbm = keywords[0]
+    assert gbm["keyword"] == "GBM"
+    assert gbm["normalized_keyword"] == "gbm"
+    assert gbm["variants"] == ["GBM", "gbm"]
+    assert gbm["annotation_count"] == 3
+    assert gbm["mention_count"] == 2
+    assert gbm["annotator_count"] == 2
+    assert gbm["labels"] == ["disease"]
+    assert gbm["canonical_ids"] == ["BERN:glioblastoma", "MESH:D005909"]
+    assert [
+        (item["source"], item["annotation_count"], item["canonical_ids"])
+        for item in gbm["annotators"]
+    ] == [
+        ("bern2", 1, ["BERN:glioblastoma"]),
+        ("pubtator3", 2, ["MESH:D005909"]),
+    ]
+    assert "mentions" not in gbm["annotators"][0]
+
+    first_mention = gbm["mentions"][0]
+    assert first_mention["start"] == 10
+    assert first_mention["end"] == 13
+    assert first_mention["annotation_count"] == 2
+    assert first_mention["annotator_count"] == 2
+    assert [item["source"] for item in first_mention["annotators"]] == ["bern2", "pubtator3"]
+    assert {item["canonical_id"] for item in first_mention["annotators"]} == {
+        "BERN:glioblastoma",
+        "MESH:D005909",
+    }

--- a/tests/test_pipeline_runner.py
+++ b/tests/test_pipeline_runner.py
@@ -16,6 +16,7 @@ from bio_annotation.pipeline_runner import (
     build_keyword_annotations,
     run_pipeline_from_config,
     run_selected_annotators,
+    run_selected_annotators_with_status,
 )
 from bio_annotation.schemas.entity import Annotation
 from bio_annotation.schemas.document import Document
@@ -424,6 +425,36 @@ def test_run_selected_annotators_passes_flair_model(monkeypatch) -> None:
     )
 
     assert calls == ["hunflair2"]
+
+
+def test_run_selected_annotators_records_failures(monkeypatch) -> None:
+    document = Document(
+        document_id="doc1",
+        title="PTEN regulates glioblastoma",
+        abstract="PTEN is important.",
+        source="corpus",
+    )
+
+    def broken_flair(document: Document, **kwargs: object) -> list[Annotation]:
+        raise RuntimeError("hunflair2 is unavailable")
+
+    monkeypatch.setattr("bio_annotation.pipeline_runner.annotate_with_flair", broken_flair)
+
+    results, statuses = run_selected_annotators_with_status(
+        document,
+        ["flair"],
+        flair_options={"model": "hunflair2"},
+    )
+
+    assert results == {"flair": []}
+    assert statuses == [
+        {
+            "name": "flair",
+            "status": "failed",
+            "annotation_count": 0,
+            "reason": "hunflair2 is unavailable",
+        }
+    ]
 
 
 def test_build_keyword_annotations_groups_by_keyword_with_mentions_and_evidence() -> None:

--- a/tests/test_pipeline_runner.py
+++ b/tests/test_pipeline_runner.py
@@ -277,6 +277,7 @@ def test_cli_run_config_outputs_payload(tmp_path, monkeypatch) -> None:
                 "failed": [],
                 "annotators": [],
             },
+            "output": {"path": "outputs/20260513-122400/test.json"},
         },
     )
 
@@ -287,7 +288,7 @@ def test_cli_run_config_outputs_payload(tmp_path, monkeypatch) -> None:
     output = stream.getvalue()
     assert exit_code == 0
     assert "Pipeline completed." in output
-    assert "Output written to: outputs/test.json" in output
+    assert "Output written to: outputs/20260513-122400/test.json" in output
     assert "Documents: 1" in output
     assert "Annotations: 0" in output
     assert "Keywords: 0" in output
@@ -332,7 +333,9 @@ def test_cli_run_config_ingestion_only(tmp_path) -> None:
     output = stream.getvalue()
     assert exit_code == 0
     assert "Pipeline completed." in output
-    assert f"Output written to: {(tmp_path / 'outputs' / 'test.json').as_posix()}" in output
+    written = sorted((tmp_path / "outputs").glob("*/test.json"))
+    assert len(written) == 1
+    assert f"Output written to: {written[0].as_posix()}" in output
     assert "Annotations: 0" in output
     assert "Annotators with results: none" in output
     assert "Annotators without results: none" in output

--- a/tests/test_pipeline_runner.py
+++ b/tests/test_pipeline_runner.py
@@ -10,11 +10,15 @@ from bio_annotation.fetch import FetchOrchestrator
 from bio_annotation.fetch.input import FetchInput, FetchKind
 from bio_annotation.schemas.document import Document
 from bio_annotation.pipeline_runner import (
+    _read_bern2_options,
+    _read_flair_options,
     _read_pubtator3_options,
     build_keyword_annotations,
     run_pipeline_from_config,
+    run_selected_annotators,
 )
 from bio_annotation.schemas.entity import Annotation
+from bio_annotation.schemas.document import Document
 
 
 @dataclass
@@ -131,8 +135,84 @@ def test_run_pipeline_from_config_with_pmids(tmp_path) -> None:
     assert payload["pipeline"]["annotators_enabled"] == ["bern2", "pubtator3"]
     assert payload["documents"][0]["metadata"]["pubmed_record"]["pmcid"] == "PMC1234567"
     assert payload["annotation_summary"]["annotation_count"] == 2
+    assert payload["annotator_summary"]["configured"] == ["bern2", "pubtator3"]
+    assert payload["annotator_summary"]["produced"] == ["bern2", "pubtator3"]
+    assert payload["annotator_summary"]["not_produced"] == []
     assert payload["document_annotations"][0]["sources"] == ["bern2", "pubtator3"]
+    assert payload["document_annotations"][0]["annotators"] == [
+        {
+            "name": "bern2",
+            "status": "produced_annotations",
+            "annotation_count": 1,
+            "reason": None,
+        },
+        {
+            "name": "pubtator3",
+            "status": "produced_annotations",
+            "annotation_count": 1,
+            "reason": None,
+        },
+    ]
     assert len(payload["annotations"]) == 2
+
+
+def test_run_pipeline_records_annotators_without_results(tmp_path) -> None:
+    config_path = tmp_path / "pipeline.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "[input]",
+                'mode = "pmids"',
+                'pmids = ["12345678"]',
+                "",
+                "[enrichment]",
+                "sources = []",
+                "",
+                "[annotators]",
+                'enabled = ["bern2", "flair"]',
+                "",
+                "[annotators.bern2]",
+                'base_url = "http://127.0.0.1:8888"',
+                "",
+                "[annotators.flair]",
+                'model = "hunflair2"',
+                "",
+                "[filters]",
+                "entity_types = []",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = run_pipeline_from_config(
+        config_path,
+        pmid_fetcher=lambda pmid: {
+            "pmid": pmid,
+            "title": "PTEN regulates glioblastoma",
+            "abstract": "PTEN is important in glioblastoma.",
+            "year": "2024",
+        },
+        bern2_request_fn=lambda document: {"annotations": []},
+        flair_spans_by_document={"PMID:12345678": []},
+    )
+
+    assert payload["annotator_summary"]["configured"] == ["bern2", "flair"]
+    assert payload["annotator_summary"]["produced"] == []
+    assert payload["annotator_summary"]["not_produced"] == ["bern2", "flair"]
+    assert payload["document_annotations"][0]["annotators"] == [
+        {
+            "name": "bern2",
+            "status": "no_annotations",
+            "annotation_count": 0,
+            "reason": "No annotations returned. Verify the Bern2 service is reachable and returned entities for this document.",
+        },
+        {
+            "name": "flair",
+            "status": "no_annotations",
+            "annotation_count": 0,
+            "reason": "No annotations returned. The Flair model may be unavailable/not cached, or it found no entities.",
+        },
+    ]
 
 
 def test_cli_run_config_outputs_payload(tmp_path, monkeypatch) -> None:
@@ -180,9 +260,22 @@ def test_cli_run_config_outputs_payload(tmp_path, monkeypatch) -> None:
             },
             "entity_types": ["gene"],
             "documents": [],
-            "annotation_summary": {"annotators_enabled": ["flair"], "document_count": 1, "annotation_count": 0},
+            "annotation_summary": {
+                "annotators_enabled": ["flair"],
+                "document_count": 1,
+                "annotation_count": 0,
+                "keyword_count": 0,
+            },
             "document_annotations": [],
+            "keywords": [],
             "annotations": [],
+            "annotator_summary": {
+                "configured": ["flair"],
+                "produced": [],
+                "not_produced": ["flair"],
+                "failed": [],
+                "annotators": [],
+            },
         },
     )
 
@@ -190,10 +283,16 @@ def test_cli_run_config_outputs_payload(tmp_path, monkeypatch) -> None:
     with redirect_stdout(stream):
         exit_code = main(["run-config", "--config", str(config_path)])
 
-    output = json.loads(stream.getvalue())
+    output = stream.getvalue()
     assert exit_code == 0
-    assert output["stage"] == "corpus"
-    assert output["pipeline"]["annotators_enabled"] == ["flair"]
+    assert "Pipeline completed." in output
+    assert "Output written to: outputs/test.json" in output
+    assert "Documents: 1" in output
+    assert "Annotations: 0" in output
+    assert "Keywords: 0" in output
+    assert "Annotators with results: none" in output
+    assert "Annotators without results: flair" in output
+    assert not output.lstrip().startswith("{")
 
 
 def test_cli_run_config_ingestion_only(tmp_path) -> None:
@@ -215,7 +314,7 @@ def test_cli_run_config_ingestion_only(tmp_path) -> None:
                 "entity_types = []",
                 "",
                 "[output]",
-                'path = "outputs/test.json"',
+                f'path = "{(tmp_path / "outputs" / "test.json").as_posix()}"',
             ]
         ),
         encoding="utf-8",
@@ -229,12 +328,14 @@ def test_cli_run_config_ingestion_only(tmp_path) -> None:
     with redirect_stdout(stream):
         exit_code = main(["run-config", "--config", str(config_path)])
 
-    output = json.loads(stream.getvalue())
+    output = stream.getvalue()
     assert exit_code == 0
-    assert output["stage"] == "corpus"
-    assert output["input"]["mode"] == "corpus"
-    assert output["pipeline"]["annotators_enabled"] == []
-    assert output["annotation_summary"]["annotation_count"] == 0
+    assert "Pipeline completed." in output
+    assert f"Output written to: {(tmp_path / 'outputs' / 'test.json').as_posix()}" in output
+    assert "Annotations: 0" in output
+    assert "Annotators with results: none" in output
+    assert "Annotators without results: none" in output
+    assert not output.lstrip().startswith("{")
 
 
 def test_read_pubtator3_options_parses_text_mode_settings() -> None:
@@ -258,6 +359,71 @@ def test_read_pubtator3_options_parses_text_mode_settings() -> None:
     assert options["poll_interval_seconds"] == 3.0
     assert options["poll_backoff"] == 2.0
     assert options["max_poll_interval_seconds"] == 12.0
+
+
+def test_read_bern2_options_prefers_endpoint_then_base_url() -> None:
+    assert _read_bern2_options({"base_url": "http://bern2.local"}) == {
+        "endpoint": "http://bern2.local"
+    }
+    assert _read_bern2_options(
+        {
+            "base_url": "http://bern2.local",
+            "endpoint": "http://bern2.local/plain",
+        }
+    ) == {"endpoint": "http://bern2.local/plain"}
+
+
+def test_run_selected_annotators_passes_bern2_endpoint(monkeypatch) -> None:
+    document = Document(
+        document_id="doc1",
+        title="PTEN regulates glioblastoma",
+        abstract="PTEN is important.",
+        source="corpus",
+    )
+    calls: list[str | None] = []
+
+    def fake_bern2(document: Document, **kwargs: object) -> list[Annotation]:
+        calls.append(kwargs.get("endpoint"))
+        return []
+
+    monkeypatch.setattr("bio_annotation.pipeline_runner.annotate_with_bern2", fake_bern2)
+
+    run_selected_annotators(
+        document,
+        ["bern2"],
+        bern2_options={"endpoint": "http://127.0.0.1:8888"},
+    )
+
+    assert calls == ["http://127.0.0.1:8888"]
+
+
+def test_read_flair_options_reads_model() -> None:
+    assert _read_flair_options({"model": "hunflair2"}) == {"model": "hunflair2"}
+    assert _read_flair_options({}) == {"model": None}
+
+
+def test_run_selected_annotators_passes_flair_model(monkeypatch) -> None:
+    document = Document(
+        document_id="doc1",
+        title="PTEN regulates glioblastoma",
+        abstract="PTEN is important.",
+        source="corpus",
+    )
+    calls: list[str | None] = []
+
+    def fake_flair(document: Document, **kwargs: object) -> list[Annotation]:
+        calls.append(kwargs.get("model"))
+        return []
+
+    monkeypatch.setattr("bio_annotation.pipeline_runner.annotate_with_flair", fake_flair)
+
+    run_selected_annotators(
+        document,
+        ["flair"],
+        flair_options={"model": "hunflair2"},
+    )
+
+    assert calls == ["hunflair2"]
 
 
 def test_build_keyword_annotations_groups_by_keyword_with_mentions_and_evidence() -> None:


### PR DESCRIPTION
## Summary
- Add keyword-first annotation output for pipeline runs.
- Group annotations by document, keyword text, and offsets.
- Preserve raw annotation output for traceability.
- Add TSV exports for easier review and downstream analysis.
- Allow pipeline runs to continue when one annotator is unavailable.

## Output changes
Adds keyword-oriented fields to the pipeline JSON payload:

- `annotation_summary.keyword_count`
- top-level `keywords`
- per-document `document_annotations[].keywords`
- per-document `document_annotations[].keyword_count`

Each keyword group includes:

- `document_id`
- `keyword`
- `start`
- `end`
- `annotation_count`
- `annotator_count`
- `labels`
- `canonical_ids`
- `annotators`

Raw `annotations` are still included for debugging and downstream use.

## TSV exports
When a JSON output path is configured, the pipeline now also writes TSV files next to it:

- `<output>.keywords.tsv`
  - One row per grouped keyword occurrence.
  - Useful for review, filtering, sorting, and consensus checks.

- `<output>.keyword_annotator_evidence.tsv`
  - One row per annotator claim for each keyword.
  - Preserves source, label, annotation ID, canonical ID/name, and confidence.

- `<output>.annotations.tsv`
  - One row per raw annotation.
  - Useful for debugging and compatibility with the previous annotation-oriented view.

Example for `outputs/three_annotators.json`:

```text
outputs/three_annotators.json
outputs/three_annotators.keywords.tsv
outputs/three_annotators.keyword_annotator_evidence.tsv
outputs/three_annotators.annotations.tsv

## Annotator availability handling
- Annotator failures are isolated per annotator.
- If one annotator is unavailable, the pipeline continues with the remaining annotators.
- Failed annotators return an empty result list for that document.
- The console reports unavailable annotators, for example:
  `bern2 unavailable: <connection error>`