### PR TITLE
Add CLI logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,12 @@ The TSV files are generated from the same payload and use the same output stem a
 
 ## Developer Checks
 
+Show diagnostic logs while running a command:
+
+```bash
+uv run totalannotator --log-level INFO run-config
+```
+
 Run the test suite:
 
 ```bash

--- a/src/bio_annotation/cli.py
+++ b/src/bio_annotation/cli.py
@@ -10,6 +10,7 @@ from bio_annotation.annotators import flatten_annotations, run_all_annotators
 from bio_annotation.benchmarking.preflight import BenchmarkPreflightError
 from bio_annotation.benchmarking.runner import run_ncbi_review_evaluation
 from bio_annotation.io.search import search_pubmed_pmids, write_pmids
+from bio_annotation.logging_config import DEFAULT_LOG_LEVEL, configure_logging
 from bio_annotation.pipeline_config import load_pipeline_config
 from bio_annotation.pipeline_runner import run_pipeline_from_config
 from bio_annotation.preprocessing.document_loader import load_documents_from_config
@@ -75,6 +76,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="totalannotator",
         description="Utilities for the TotalAnnotator biomedical annotation project.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default=DEFAULT_LOG_LEVEL,
+        choices=("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
+        help="Diagnostic log level. Default: WARNING.",
     )
     subparsers = parser.add_subparsers(dest="command")
 
@@ -174,6 +181,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    configure_logging(args.log_level)
 
     if args.command in (None, "info"):
         print("TotalAnnotator")

--- a/src/bio_annotation/logging_config.py
+++ b/src/bio_annotation/logging_config.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import logging
+
+DEFAULT_LOG_LEVEL = "WARNING"
+LOG_FORMAT = "%(levelname)s:%(name)s:%(message)s"
+
+
+def configure_logging(level: str | int = DEFAULT_LOG_LEVEL) -> None:
+    logging.basicConfig(
+        level=_normalize_log_level(level),
+        format=LOG_FORMAT,
+        force=True,
+    )
+
+
+def _normalize_log_level(level: str | int) -> int:
+    if isinstance(level, int):
+        return level
+    normalized = level.strip().upper()
+    if not normalized:
+        return logging.WARNING
+    value = getattr(logging, normalized, None)
+    if isinstance(value, int):
+        return value
+    raise ValueError(f"Unsupported log level: {level}")

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -4,7 +4,6 @@ import ast
 import csv
 import json
 import logging
-import sys
 from datetime import datetime
 from importlib.util import find_spec
 from pathlib import Path
@@ -31,6 +30,7 @@ FLAIR_INSTALL_HINT = (
     "The Flair annotator requires the optional Flair dependency. "
     "Install it with: uv sync --extra flair"
 )
+logger = logging.getLogger(__name__)
 
 
 def run_pipeline_from_config(
@@ -110,7 +110,7 @@ def build_pipeline_output(
         try:
             flair_tagger = _load_flair_tagger(flair_options["model"] or "hunflair2")
         except Exception as exc:
-            print(f"flair unavailable: {exc}")
+            logger.warning("flair unavailable: %s", exc)
     document_annotations: list[dict[str, Any]] = []
     annotations_output: list[dict[str, Any]] = []
     keyword_output: list[dict[str, Any]] = []
@@ -514,7 +514,7 @@ def run_selected_annotators_with_status(
             else:
                 raise ValueError(f"Unsupported annotator: {annotator}")
         except Exception as exc:
-            print(f"{annotator} unavailable: {exc}")
+            logger.warning("%s unavailable: %s", annotator, exc)
             results[annotator] = []
             statuses.append(
                 {
@@ -763,12 +763,13 @@ def _pubtator3_progress(
     max_attempts: int,
     sleep_seconds: float,
 ) -> None:
-    print(
+    logger.info(
         "pubtator3 pending: "
-        f"session={session_id} attempt={attempt}/{max_attempts}; "
-        f"sleeping {sleep_seconds:.1f}s",
-        file=sys.stderr,
-        flush=True,
+        "session=%s attempt=%s/%s; sleeping %.1fs",
+        session_id,
+        attempt,
+        max_attempts,
+        sleep_seconds,
     )
 
 

--- a/tests/test_annotators.py
+++ b/tests/test_annotators.py
@@ -613,6 +613,16 @@ def test_cli_inspect_config_runs() -> None:
     assert output["annotator_settings"]["pubtator3"]["endpoint"] == "https://www.ncbi.nlm.nih.gov/research/pubtator3-api"
 
 
+def test_cli_accepts_global_log_level_before_subcommand() -> None:
+    stream = StringIO()
+    with redirect_stdout(stream):
+        exit_code = main(["--log-level", "ERROR", "inspect-config"])
+
+    output = json.loads(stream.getvalue())
+    assert exit_code == 0
+    assert output["input_mode"] == "pmids"
+
+
 def test_cli_load_documents_runs(monkeypatch) -> None:
     monkeypatch.setattr(
         "bio_annotation.preprocessing.document_loader.fetch_pubmed_record",

--- a/tests/test_pipeline_runner.py
+++ b/tests/test_pipeline_runner.py
@@ -481,7 +481,7 @@ def test_run_selected_annotators_passes_flair_model(monkeypatch) -> None:
     assert calls == ["hunflair2"]
 
 
-def test_run_selected_annotators_records_failures(monkeypatch) -> None:
+def test_run_selected_annotators_records_failures(monkeypatch, caplog) -> None:
     document = Document(
         document_id="doc1",
         title="PTEN regulates glioblastoma",
@@ -494,11 +494,12 @@ def test_run_selected_annotators_records_failures(monkeypatch) -> None:
 
     monkeypatch.setattr("bio_annotation.pipeline_runner.annotate_with_flair", broken_flair)
 
-    results, statuses = run_selected_annotators_with_status(
-        document,
-        ["flair"],
-        flair_options={"model": "hunflair2"},
-    )
+    with caplog.at_level("WARNING", logger="bio_annotation.pipeline_runner"):
+        results, statuses = run_selected_annotators_with_status(
+            document,
+            ["flair"],
+            flair_options={"model": "hunflair2"},
+        )
 
     assert results == {"flair": []}
     assert statuses == [
@@ -509,6 +510,7 @@ def test_run_selected_annotators_records_failures(monkeypatch) -> None:
             "reason": "hunflair2 is unavailable",
         }
     ]
+    assert "flair unavailable: hunflair2 is unavailable" in caplog.text
 
 
 def test_build_keyword_annotations_groups_by_keyword_with_mentions_and_evidence() -> None:


### PR DESCRIPTION
## Summary

  Adds a small stdlib logging setup for TotalAnnotator.

  This introduces a global CLI option:

  ```bash
  uv run totalannotator --log-level INFO run-config
  ```
  The option must be placed before the subcommand.

  ## Changes

  - Added bio_annotation.logging_config
  - Added global --log-level CLI option
  - Replaced internal pipeline_runner diagnostic prints with logger calls
  - Kept user-facing CLI summaries as print()
  - Documented the new logging option in the README

  ## Why

  This separates user-facing command output from diagnostics like:

  - unavailable annotators
  - Flair model loading failures
  - PubTator3 polling progress

  This should help both terminal use and future web/backend use.

  ## Validation

  git diff --check origin/main...HEAD
  uv run pytest -q

  Result:

  143 passed, 1 skipped, 2 warnings