### PR TITLE
Medcat

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,23 @@ HunFlair supports:
 
 HunFlair does not produce variants/mutations. If the terminal UI selection includes unsupported entity types for a selected annotator, it shows a compatibility warning before continuing.
 
+### MedCAT
+
+MedCAT runs as a separate service, CogStack MedCATservice, that TotalAnnotator calls over HTTP, like BERN2. Unlike BERN2 there is no public endpoint, so you run the service yourself and point TotalAnnotator at it. The generated terminal UI config uses:
+
+```toml
+[annotators.medcat]
+runtime = "remote_api"
+endpoint = "http://localhost:5555"
+min_acc = 0.3
+```
+
+The endpoint defaults to `http://localhost:5555` (the CogStack docker-compose default) and can be overridden with the `MEDCAT_API_URL` environment variable or the `endpoint` setting. `min_acc` (0..1) drops low-confidence concepts.
+
+To start the service: clone [CogStack/MedCATservice](https://github.com/CogStack/MedCATservice), download a model pack (the MedMen demo, or a clinical UMLS/SNOMED pack for real use), then run `docker compose up -d` from its `docker/` folder and check `http://localhost:5555/api/info`. If MedCAT is selected in the terminal UI and no service is reachable, TotalAnnotator warns before the run; if none is reachable at run time, the MedCAT step simply returns no annotations and the rest of the run continues.
+
+MedCAT entity types are the model pack's semantic types (UMLS TUIs), so they pass through as returned rather than mapping to the canonical types below.
+
 ## Entity Types
 
 TotalAnnotator normalizes annotator labels into canonical entity types:

--- a/src/bio_annotation/annotators/__init__.py
+++ b/src/bio_annotation/annotators/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 from bio_annotation.annotators.aioner import annotate_with_aioner
 from bio_annotation.annotators.bern2 import annotate_with_bern2
 from bio_annotation.annotators.flair import annotate_with_flair
+from bio_annotation.annotators.medcat import annotate_with_medcat
 from bio_annotation.annotators.pubtator3 import annotate_with_pubtator3
 from bio_annotation.schemas.document import Document
 from bio_annotation.schemas.entity import Annotation
@@ -26,6 +27,9 @@ def run_all_annotators(
     pubtator3_endpoint: str | None = None,
     aioner_response: Any = None,
     aioner_request_fn: Any = None,
+    medcat_response: Any = None,
+    medcat_request_fn: Any = None,
+    medcat_endpoint: str | None = None,
 ) -> dict[str, list[Annotation]]:
     results = {
         "bern2": annotate_with_bern2(
@@ -56,12 +60,26 @@ def run_all_annotators(
             response=aioner_response,
             request_fn=aioner_request_fn,
         )
+    # MedCAT calls a remote service, so only invoke it when an explicit response,
+    # request function, or endpoint is supplied (avoids hitting a service in
+    # callers that don't use it, e.g. the demo command).
+    if (
+        medcat_response is not None
+        or medcat_request_fn is not None
+        or medcat_endpoint is not None
+    ):
+        results["medcat"] = annotate_with_medcat(
+            document,
+            response=medcat_response,
+            request_fn=medcat_request_fn,
+            endpoint=medcat_endpoint,
+        )
     return results
 
 
 def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation]:
     annotations: list[Annotation] = []
-    for source in ("bern2", "flair", "pubtator3", "aioner"):
+    for source in ("bern2", "flair", "pubtator3", "aioner", "medcat"):
         annotations.extend(results.get(source, []))
     return annotations
 
@@ -69,6 +87,7 @@ __all__ = [
     "annotate_with_aioner",
     "annotate_with_bern2",
     "annotate_with_flair",
+    "annotate_with_medcat",
     "annotate_with_pubtator3",
     "flatten_annotations",
     "run_all_annotators",

--- a/src/bio_annotation/annotators/medcat.py
+++ b/src/bio_annotation/annotators/medcat.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from bio_annotation.entity_proposal.medcat_proposer import (
+    annotate_with_medcat,
+    call_medcat,
+    parse_medcat_response,
+)
+
+__all__ = ["annotate_with_medcat", "call_medcat", "parse_medcat_response"]

--- a/src/bio_annotation/entity_proposal/__init__.py
+++ b/src/bio_annotation/entity_proposal/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 from bio_annotation.entity_proposal.aioner_proposer import annotate_with_aioner
 from bio_annotation.entity_proposal.bern2_proposer import annotate_with_bern2
 from bio_annotation.entity_proposal.flair_proposer import annotate_with_flair
+from bio_annotation.entity_proposal.medcat_proposer import annotate_with_medcat
 from bio_annotation.entity_proposal.pubtator3_proposer import annotate_with_pubtator3
 from bio_annotation.schemas.document import Document
 from bio_annotation.schemas.entity import Annotation
@@ -26,6 +27,9 @@ def run_all_annotators(
     pubtator3_endpoint: str | None = None,
     aioner_response: Any = None,
     aioner_request_fn: Any = None,
+    medcat_response: Any = None,
+    medcat_request_fn: Any = None,
+    medcat_endpoint: str | None = None,
 ) -> dict[str, list[Annotation]]:
     """Run all configured annotator adapters and return normalized outputs."""
 
@@ -56,12 +60,24 @@ def run_all_annotators(
             response=aioner_response,
             request_fn=aioner_request_fn,
         )
+    # Only invoke MedCAT when a response, request function, or endpoint is provided.
+    if (
+        medcat_response is not None
+        or medcat_request_fn is not None
+        or medcat_endpoint is not None
+    ):
+        results["medcat"] = annotate_with_medcat(
+            document,
+            response=medcat_response,
+            request_fn=medcat_request_fn,
+            endpoint=medcat_endpoint,
+        )
     return results
 
 
 def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation]:
     annotations: list[Annotation] = []
-    for source in ("bern2", "flair", "pubtator3", "aioner"):
+    for source in ("bern2", "flair", "pubtator3", "aioner", "medcat"):
         annotations.extend(results.get(source, []))
     return annotations
 
@@ -70,6 +86,7 @@ __all__ = [
     "annotate_with_aioner",
     "annotate_with_bern2",
     "annotate_with_flair",
+    "annotate_with_medcat",
     "annotate_with_pubtator3",
     "flatten_annotations",
     "run_all_annotators",

--- a/src/bio_annotation/entity_proposal/medcat_proposer.py
+++ b/src/bio_annotation/entity_proposal/medcat_proposer.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import warnings
+from typing import Any, Callable
+from urllib import error, parse, request
+
+from bio_annotation.entity_proposal._shared import make_annotation, pick_first
+from bio_annotation.schemas.document import Document
+from bio_annotation.schemas.entity import Annotation
+
+logger = logging.getLogger(__name__)
+
+# MedCAT has no public endpoint; the CogStack MedCATservice docker-compose maps
+# the service to localhost:5555 by default, so an unconfigured run still reaches
+# a local service. MEDCAT_API_URL or an explicit endpoint override this.
+DEFAULT_MEDCAT_API_URL = "http://localhost:5555"
+
+
+def _normalize_medcat_process_url(url: str) -> str:
+    """CogStack MedCATservice expects POST ``/api/process``. Users often set only host:port."""
+
+    raw = (url or "").strip()
+    if not raw:
+        return raw
+    if raw.rstrip("/").lower().endswith("/api/process"):
+        return raw.rstrip("/")
+    parsed = parse.urlparse(raw)
+    if not parsed.scheme or not parsed.netloc:
+        return raw
+    if parsed.path.rstrip("/").endswith("/api/process"):
+        return raw.rstrip("/")
+    return parse.urljoin(raw.rstrip("/") + "/", "api/process")
+
+
+def _medcat_min_acc_threshold(explicit: float | None) -> float | None:
+    """Optional 0..1 cutoff on MedCAT ``acc`` / ``context_similarity`` (see env ``MEDCAT_MIN_ACC``)."""
+
+    if explicit is not None:
+        return explicit if explicit > 0.0 else None
+    raw = os.getenv("MEDCAT_MIN_ACC", "").strip()
+    if not raw:
+        return None
+    try:
+        v = float(raw)
+    except ValueError:
+        return None
+    return v if v > 0.0 else None
+
+
+def _first_nonempty_str_list(value: Any) -> str | None:
+    if not isinstance(value, list) or not value:
+        return None
+    first = value[0]
+    if first is None:
+        return None
+    text = str(first).strip()
+    return text or None
+
+
+def _looks_like_entity_record(item: dict[str, Any]) -> bool:
+    if not item:
+        return False
+    return bool(
+        item.get("cui")
+        or item.get("pretty_name")
+        or item.get("source_value")
+        or item.get("value")
+        or item.get("mention")
+    )
+
+
+def _flatten_annotation_value(raw: Any) -> list[dict[str, Any]]:
+    """Normalize MedCAT / MedCATservice annotation containers to flat entity dicts."""
+
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        out: list[dict[str, Any]] = []
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            vals = [v for v in item.values() if isinstance(v, dict)]
+            if (
+                vals
+                and len(vals) == len(item)
+                and any(_looks_like_entity_record(v) for v in vals)
+            ):
+                out.extend(vals)
+            else:
+                out.append(item)
+        return [x for x in out if _looks_like_entity_record(x)]
+    if isinstance(raw, dict):
+        nested_ent = raw.get("entities")
+        if isinstance(nested_ent, dict) and nested_ent:
+            inner = _flatten_annotation_value(nested_ent)
+            if inner:
+                return inner
+        vals = [v for v in raw.values() if isinstance(v, dict)]
+        if vals and len(vals) == len(raw) and any(_looks_like_entity_record(v) for v in vals):
+            return vals
+        if _looks_like_entity_record(raw):
+            return [raw]
+    return []
+
+
+def _extract_records(payload: Any) -> list[dict[str, Any]]:
+    if payload is None:
+        return []
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict) and _looks_like_entity_record(item)]
+
+    if not isinstance(payload, dict):
+        return []
+
+    # CogStack MedCATservice: { "result": { "annotations": ... } }
+    # MedCAT 1.2+ often uses annotations: { "entities": { "0": {...}, ... }, "tokens": [...] }.
+    result = payload.get("result")
+    if isinstance(result, dict):
+        ann = result.get("annotations")
+        if isinstance(ann, dict):
+            nested = ann.get("entities")
+            if isinstance(nested, dict) and nested:
+                records = _flatten_annotation_value(nested)
+                if records:
+                    return records
+        for key in ("annotations", "entities"):
+            records = _flatten_annotation_value(result.get(key))
+            if records:
+                return records
+
+    for key in ("entities", "annotations", "results", "denotations"):
+        records = _flatten_annotation_value(payload.get(key))
+        if records:
+            return records
+
+    if _looks_like_entity_record(payload):
+        return [payload]
+    return []
+
+
+def parse_medcat_response(
+    document: Document,
+    payload: Any,
+    *,
+    min_acc: float | None = None,
+) -> list[Annotation]:
+    """Parse MedCATservice JSON. Set ``min_acc`` or ``MEDCAT_MIN_ACC`` to drop low-confidence spans."""
+
+    threshold = _medcat_min_acc_threshold(min_acc)
+    annotations: list[Annotation] = []
+    for record in _extract_records(payload):
+        mention = pick_first(
+            record.get("value"),
+            record.get("source_value"),
+            record.get("detected_name"),
+            record.get("mention"),
+            record.get("text"),
+            record.get("pretty_name"),
+        )
+        if not mention:
+            continue
+        raw_conf = pick_first(
+            record.get("acc"),
+            record.get("context_similarity"),
+            record.get("confidence"),
+            record.get("score"),
+        )
+        if threshold is not None:
+            try:
+                conf_f = float(raw_conf) if raw_conf is not None else None
+            except (TypeError, ValueError):
+                conf_f = None
+            if conf_f is None or conf_f < threshold:
+                continue
+
+        annotations.append(
+            make_annotation(
+                document=document,
+                source="medcat",
+                span_text=mention,
+                entity_type=pick_first(
+                    record.get("type"),
+                    record.get("entity_type"),
+                    record.get("tui"),
+                    record.get("semantic_type"),
+                    _first_nonempty_str_list(record.get("type_ids")),
+                    _first_nonempty_str_list(record.get("types")),
+                    "concept",
+                ),
+                start=pick_first(
+                    record.get("start"),
+                    record.get("start_char"),
+                    record.get("begin"),
+                ),
+                end=pick_first(
+                    record.get("end"),
+                    record.get("end_char"),
+                ),
+                canonical_id=pick_first(
+                    record.get("cui"),
+                    record.get("id"),
+                    record.get("concept_id"),
+                ),
+                canonical_name=pick_first(
+                    record.get("pretty_name"),
+                    record.get("name"),
+                    record.get("preferred_name"),
+                ),
+                confidence=pick_first(
+                    record.get("acc"),
+                    record.get("confidence"),
+                    record.get("score"),
+                ),
+            )
+        )
+    return annotations
+
+
+def call_medcat(document: Document, endpoint: str | None = None, timeout: int = 45) -> Any:
+    target = _normalize_medcat_process_url(endpoint or os.getenv("MEDCAT_API_URL") or DEFAULT_MEDCAT_API_URL)
+    if not target:
+        return None
+    text = document.get_text()
+    # CogStack MedCATservice POST /api/process uses {"content": {"text": ...}}; we also send top-level "text".
+    body: dict[str, Any] = {
+        "text": text,
+        "content": {"text": text},
+    }
+    payload = json.dumps(body).encode("utf-8")
+    http_request = request.Request(
+        target,
+        data=payload,
+        headers={"Content-Type": "application/json", "User-Agent": "TotalAnnotator/medcat-client"},
+        method="POST",
+    )
+    try:
+        with request.urlopen(http_request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except error.HTTPError as exc:
+        try:
+            detail = exc.read().decode("utf-8", errors="replace")[:500]
+        except Exception:  # noqa: BLE001
+            detail = ""
+        msg = f"{exc.code} {exc.reason} {detail}".strip()
+        warnings.warn(f"MedCAT HTTP error for {target!r}: {msg}", UserWarning, stacklevel=2)
+        logger.warning("MedCAT HTTP error %s", msg)
+        return None
+    except (error.URLError, json.JSONDecodeError, TimeoutError, OSError) as exc:
+        warnings.warn(f"MedCAT request to {target!r} failed: {exc}", UserWarning, stacklevel=2)
+        logger.warning("MedCAT request failed: %s", exc)
+        return None
+
+
+def annotate_with_medcat(
+    document: Document,
+    *,
+    response: Any = None,
+    request_fn: Callable[[Document], Any] | None = None,
+    endpoint: str | None = None,
+    min_acc: float | None = None,
+) -> list[Annotation]:
+    payload = response
+    if payload is None and request_fn is not None:
+        payload = request_fn(document)
+    if payload is None:
+        payload = call_medcat(document, endpoint=endpoint)
+    return parse_medcat_response(document, payload, min_acc=min_acc)
+
+
+__all__ = ["DEFAULT_MEDCAT_API_URL", "annotate_with_medcat", "call_medcat", "parse_medcat_response"]

--- a/src/bio_annotation/entity_types.py
+++ b/src/bio_annotation/entity_types.py
@@ -149,6 +149,24 @@ ANNOTATOR_CAPABILITIES: dict[str, AnnotatorCapability] = {
         },
         normalization_fields=(),
     ),
+    "medcat": AnnotatorCapability(
+        label="MedCAT",
+        tasks=("NER", "NEN"),
+        # MedCAT's entity types depend on the loaded model pack (UMLS/SNOMED), so
+        # they pass through as returned rather than mapping to the canonical set.
+        entity_types=tuple(
+            spec.canonical_entity_type
+            for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+            if spec.annotator == "medcat"
+        ),
+        normalization_status="normalized",
+        normalization_databases={
+            spec.canonical_entity_type: spec.database_ids
+            for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+            if spec.annotator == "medcat"
+        },
+        normalization_fields=("cui",),
+    ),
 }
 
 ANNOTATOR_CHOICES: tuple[tuple[str, str], ...] = tuple(

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -12,6 +12,7 @@ from typing import Any, Callable
 from bio_annotation.annotators.aioner import annotate_with_aioner
 from bio_annotation.annotators.bern2 import annotate_with_bern2
 from bio_annotation.annotators.flair import annotate_with_flair
+from bio_annotation.annotators.medcat import annotate_with_medcat
 from bio_annotation.annotators.pubtator3 import annotate_with_pubtator3
 from bio_annotation.entity_types import normalize_entity_type
 from bio_annotation.pipeline_config import PipelineConfig, load_pipeline_config
@@ -25,7 +26,7 @@ from bio_annotation.preprocessing.document_loader import (
 from bio_annotation.schemas.document import Document
 from bio_annotation.schemas.entity import Annotation
 
-SUPPORTED_ANNOTATORS = {"bern2", "flair", "pubtator3", "aioner"}
+SUPPORTED_ANNOTATORS = {"bern2", "flair", "pubtator3", "aioner", "medcat"}
 FLAIR_INSTALL_HINT = (
     "The Flair annotator requires the optional Flair dependency. "
     "Install it with: uv sync --extra flair"
@@ -42,6 +43,7 @@ def run_pipeline_from_config(
     pubtator3_request_fn: Callable[[Document], Any] | None = None,
     flair_spans_by_document: dict[str, list[Any]] | None = None,
     aioner_request_fn: Callable[[Document], Any] | None = None,
+    medcat_request_fn: Callable[[Document], Any] | None = None,
 ) -> dict[str, Any]:
     config = load_pipeline_config(config_path)
     validate_optional_annotator_dependencies(
@@ -74,6 +76,7 @@ def run_pipeline_from_config(
         pubtator3_request_fn=pubtator3_request_fn,
         flair_spans_by_document=flair_spans_by_document,
         aioner_request_fn=aioner_request_fn,
+        medcat_request_fn=medcat_request_fn,
     )
     if config.output_path is not None:
         actual_output_path = timestamped_output_path(config.output_path)
@@ -94,6 +97,7 @@ def build_pipeline_output(
     pubtator3_request_fn: Callable[[Document], Any] | None = None,
     flair_spans_by_document: dict[str, list[Any]] | None = None,
     aioner_request_fn: Callable[[Document], Any] | None = None,
+    medcat_request_fn: Callable[[Document], Any] | None = None,
 ) -> dict[str, Any]:
     enabled_annotators = list(config.annotators)
     annotator_settings = dict(config.annotator_settings)
@@ -104,6 +108,7 @@ def build_pipeline_output(
     pubtator3_options = _read_pubtator3_options(annotator_settings.get("pubtator3", {}))
     flair_options = _read_flair_options(annotator_settings.get("flair", {}))
     aioner_options = _read_aioner_options(annotator_settings.get("aioner", {}))
+    medcat_options = _read_medcat_options(annotator_settings.get("medcat", {}))
 
     flair_tagger = None
     if "flair" in enabled_annotators and flair_spans_by_document is None:
@@ -130,9 +135,11 @@ def build_pipeline_output(
             bern2_request_fn=bern2_request_fn,
             pubtator3_request_fn=pubtator3_request_fn,
             aioner_request_fn=aioner_request_fn,
+            medcat_request_fn=medcat_request_fn,
             bern2_options=bern2_options,
             pubtator3_options=pubtator3_options,
             aioner_options=aioner_options,
+            medcat_options=medcat_options,
             flair_spans=(
                 flair_spans_by_document.get(document.document_id)
                 if flair_spans_by_document is not None
@@ -394,9 +401,11 @@ def run_selected_annotators(
     bern2_request_fn: Callable[[Document], Any] | None = None,
     pubtator3_request_fn: Callable[[Document], Any] | None = None,
     aioner_request_fn: Callable[[Document], Any] | None = None,
+    medcat_request_fn: Callable[[Document], Any] | None = None,
     bern2_options: dict[str, Any] | None = None,
     pubtator3_options: dict[str, Any] | None = None,
     aioner_options: dict[str, Any] | None = None,
+    medcat_options: dict[str, Any] | None = None,
     flair_spans: list[Any] | None = None,
     flair_tagger: Any = None,
     flair_options: dict[str, Any] | None = None,
@@ -407,9 +416,11 @@ def run_selected_annotators(
         bern2_request_fn=bern2_request_fn,
         pubtator3_request_fn=pubtator3_request_fn,
         aioner_request_fn=aioner_request_fn,
+        medcat_request_fn=medcat_request_fn,
         bern2_options=bern2_options,
         pubtator3_options=pubtator3_options,
         aioner_options=aioner_options,
+        medcat_options=medcat_options,
         flair_spans=flair_spans,
         flair_tagger=flair_tagger,
         flair_options=flair_options,
@@ -424,9 +435,11 @@ def run_selected_annotators_with_status(
     bern2_request_fn: Callable[[Document], Any] | None = None,
     pubtator3_request_fn: Callable[[Document], Any] | None = None,
     aioner_request_fn: Callable[[Document], Any] | None = None,
+    medcat_request_fn: Callable[[Document], Any] | None = None,
     bern2_options: dict[str, Any] | None = None,
     pubtator3_options: dict[str, Any] | None = None,
     aioner_options: dict[str, Any] | None = None,
+    medcat_options: dict[str, Any] | None = None,
     flair_spans: list[Any] | None = None,
     flair_tagger: Any = None,
     flair_options: dict[str, Any] | None = None,
@@ -515,6 +528,13 @@ def run_selected_annotators_with_status(
                     if aioner_options
                     else 600,
                 )
+            elif annotator == "medcat":
+                results[annotator] = annotate_with_medcat(
+                    document,
+                    request_fn=medcat_request_fn,
+                    endpoint=medcat_options.get("endpoint") if medcat_options else None,
+                    min_acc=medcat_options.get("min_acc") if medcat_options else None,
+                )
             else:
                 raise ValueError(f"Unsupported annotator: {annotator}")
         except Exception as exc:
@@ -551,7 +571,7 @@ def run_selected_annotators_with_status(
 
 def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation]:
     annotations: list[Annotation] = []
-    for source in ("bern2", "flair", "pubtator3", "aioner"):
+    for source in ("bern2", "flair", "pubtator3", "aioner", "medcat"):
         annotations.extend(results.get(source, []))
     return annotations
 
@@ -753,6 +773,12 @@ def _no_annotations_reason(annotator: str) -> str:
             "(tools/aioner/setup.sh) and annotators.aioner.repo/model are set, "
             "or it found no entities."
         )
+    if annotator == "medcat":
+        return (
+            "No annotations returned. Verify the MedCAT service is reachable "
+            "(set annotators.medcat.endpoint or MEDCAT_API_URL) and returned "
+            "entities for this document."
+        )
     return "No annotations returned."
 
 
@@ -931,6 +957,27 @@ def _read_bern2_options(settings: dict[str, object]) -> dict[str, Any]:
 
     return {
         "endpoint": cleaned_endpoint,
+    }
+
+
+def _read_medcat_options(settings: dict[str, object]) -> dict[str, Any]:
+    endpoint = settings.get("endpoint")
+    base_url = settings.get("base_url")
+
+    cleaned_endpoint = None
+    if isinstance(endpoint, str) and endpoint.strip():
+        cleaned_endpoint = endpoint.strip()
+    elif isinstance(base_url, str) and base_url.strip():
+        cleaned_endpoint = base_url.strip()
+
+    min_acc_raw = settings.get("min_acc")
+    min_acc = None
+    if isinstance(min_acc_raw, (int, float)) and float(min_acc_raw) > 0.0:
+        min_acc = float(min_acc_raw)
+
+    return {
+        "endpoint": cleaned_endpoint,
+        "min_acc": min_acc,
     }
 
 

--- a/src/bio_annotation/terminal_ui.py
+++ b/src/bio_annotation/terminal_ui.py
@@ -91,6 +91,15 @@ def run_terminal_annotation_ui(
                 "Run tools/aioner/setup.sh first, or set AIONER_REPO / AIONER_MODEL; "
                 "otherwise the AIONER step will be skipped this run."
             )
+    if "medcat" in answers.annotators:
+        medcat_endpoint = medcat_config_endpoint()
+        if not _medcat_service_reachable(medcat_endpoint):
+            output_fn(
+                f"Warning: no MedCAT service reachable at {medcat_endpoint}. "
+                "Start CogStack MedCATservice (see the MedCAT section in README) "
+                "or set MEDCAT_API_URL; otherwise the MedCAT step will return no "
+                "annotations this run."
+            )
     output_fn("")
     output_fn("Running annotation...")
     payload = pipeline_run_fn(paths.config_path)
@@ -192,6 +201,20 @@ def aioner_config_paths() -> tuple[str, str]:
 
 def medcat_config_endpoint() -> str:
     return os.environ.get("MEDCAT_API_URL") or DEFAULT_MEDCAT_API_URL
+
+
+def _medcat_service_reachable(endpoint: str, *, timeout: float = 3.0) -> bool:
+    """Best-effort check that a MedCATservice answers at the endpoint's /api/info."""
+    from urllib import request as urlrequest
+
+    base = endpoint.rstrip("/")
+    if base.endswith("/api/process"):
+        base = base[: -len("/api/process")]
+    try:
+        with urlrequest.urlopen(base + "/api/info", timeout=timeout):
+            return True
+    except Exception:
+        return False
 
 
 def build_terminal_ui_config_text(answers: TerminalUIAnswers, paths: RunPaths) -> str:

--- a/src/bio_annotation/terminal_ui.py
+++ b/src/bio_annotation/terminal_ui.py
@@ -14,6 +14,7 @@ from bio_annotation.entity_proposal.aioner_proposer import (
     DEFAULT_AIONER_PROJECT,
 )
 from bio_annotation.entity_proposal.bern2_proposer import DEFAULT_BERN2_API_URL
+from bio_annotation.entity_proposal.medcat_proposer import DEFAULT_MEDCAT_API_URL
 from bio_annotation.entity_types import (
     ANNOTATOR_CHOICES,
     ANNOTATOR_DISPLAY_NAMES,
@@ -139,9 +140,9 @@ def collect_terminal_ui_answers(*, input_fn: InputFn, output_fn: OutputFn) -> Te
         output_fn=output_fn,
         title="Choose annotators",
         choices=ANNOTATOR_CHOICES,
-        # AIONER requires a separate environment + downloaded models, so it is
-        # offered as a choice but not pre-selected by default.
-        default_values=[value for value, _ in ANNOTATOR_CHOICES if value != "aioner"],
+        # AIONER needs a separate environment + models and MedCAT needs a running
+        # MedCATservice, so both are offered as choices but not pre-selected.
+        default_values=[value for value, _ in ANNOTATOR_CHOICES if value not in {"aioner", "medcat"}],
         validate_values=_validate_selected_annotators,
     )
     entity_types = _prompt_entity_types(input_fn=input_fn, output_fn=output_fn, annotators=annotators)
@@ -189,6 +190,10 @@ def aioner_config_paths() -> tuple[str, str]:
     return repo, model
 
 
+def medcat_config_endpoint() -> str:
+    return os.environ.get("MEDCAT_API_URL") or DEFAULT_MEDCAT_API_URL
+
+
 def build_terminal_ui_config_text(answers: TerminalUIAnswers, paths: RunPaths) -> str:
     lines = ["[input]"]
     if answers.input_mode == "pmids":
@@ -211,6 +216,8 @@ def build_terminal_ui_config_text(answers: TerminalUIAnswers, paths: RunPaths) -
     if "aioner" in answers.annotators:
         aioner_repo, aioner_model = aioner_config_paths()
         lines += ["", "[annotators.aioner]", 'runtime = "local_subprocess"', f"repo = {_toml_string(aioner_repo)}", f"model = {_toml_string(aioner_model)}", f"entity = {_toml_string(DEFAULT_AIONER_ENTITY)}", f"project = {_toml_string(DEFAULT_AIONER_PROJECT)}"]
+    if "medcat" in answers.annotators:
+        lines += ["", "[annotators.medcat]", 'runtime = "remote_api"', f"endpoint = {_toml_string(medcat_config_endpoint())}", "min_acc = 0.3"]
     lines += ["", "[filters]", f"entity_types = {_toml_string_list(answers.entity_types)}", "", "[output]", f"path = {_toml_string(str(paths.results_path))}", ""]
     return "\n".join(lines)
 

--- a/tests/test_medcat_proposer.py
+++ b/tests/test_medcat_proposer.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from bio_annotation.entity_proposal.medcat_proposer import (
+    _extract_records,
+    _normalize_medcat_process_url,
+    parse_medcat_response,
+)
+from bio_annotation.schemas.document import Document
+
+
+def test_normalize_medcat_process_url_appends_api_process() -> None:
+    assert _normalize_medcat_process_url("http://127.0.0.1:5555") == "http://127.0.0.1:5555/api/process"
+    assert _normalize_medcat_process_url("http://127.0.0.1:5555/") == "http://127.0.0.1:5555/api/process"
+    assert (
+        _normalize_medcat_process_url("http://127.0.0.1:5555/api/process")
+        == "http://127.0.0.1:5555/api/process"
+    )
+
+
+def test_extract_records_medcat_annotations_entities_wrapper() -> None:
+    payload = {
+        "result": {
+            "annotations": {
+                "entities": {
+                    "0": {
+                        "cui": "C001",
+                        "source_value": "glioblastoma",
+                        "start": 10,
+                        "end": 22,
+                        "pretty_name": "Glioblastoma",
+                    }
+                },
+                "tokens": [],
+            },
+            "success": True,
+        }
+    }
+    records = _extract_records(payload)
+    assert len(records) == 1
+    assert records[0]["source_value"] == "glioblastoma"
+
+
+def test_parse_medcat_response_nested_entities() -> None:
+    doc = Document(
+        document_id="PMID:1",
+        pmid="1",
+        title="T",
+        abstract="x" * 30,
+        source="pubmed",
+    )
+    payload = {
+        "result": {
+            "annotations": {
+                "entities": {
+                    "0": {
+                        "cui": "C0023418",
+                        "type_ids": ["T191"],
+                        "types": ["Neoplastic Process"],
+                        "source_value": "glioma",
+                        "start": 5,
+                        "end": 11,
+                    }
+                },
+                "tokens": [],
+            }
+        }
+    }
+    anns = parse_medcat_response(doc, payload)
+    assert len(anns) == 1
+    assert anns[0].span_text == "glioma"
+    assert anns[0].canonical_id == "C0023418"
+
+
+def test_parse_medcat_response_min_acc_filters_weak_spans() -> None:
+    doc = Document(
+        document_id="PMID:1",
+        pmid="1",
+        title="Test",
+        abstract="alpha beta gamma",
+        source="pubmed",
+    )
+    payload = {
+        "result": {
+            "annotations": {
+                "entities": {
+                    "0": {
+                        "cui": "C1",
+                        "source_value": "alpha",
+                        "acc": 0.2,
+                        "start": 0,
+                        "end": 5,
+                    },
+                    "1": {
+                        "cui": "C2",
+                        "source_value": "beta",
+                        "acc": 0.85,
+                        "start": 6,
+                        "end": 10,
+                    },
+                },
+                "tokens": [],
+            }
+        }
+    }
+    anns = parse_medcat_response(doc, payload, min_acc=0.5)
+    assert len(anns) == 1
+    assert anns[0].span_text == "beta"


### PR DESCRIPTION

## Summary
Adds MedCAT as an annotator. It calls a CogStack MedCATservice over HTTP and parses the returned concepts (CUI, name, confidence, semantic type), wired into the pipeline like the other remote annotators and registered as NER + NEN.

## Usage
MedCAT needs a running MedCATservice; unlike BERN2 there is no public endpoint, so you run your own. The endpoint defaults to http://localhost:5555 (the CogStack docker-compose default) and is overridable via MEDCAT_API_URL or annotators.medcat.endpoint, so a config-driven or terminal-UI run reaches a local service automatically. The README MedCAT section documents starting the service with Docker. If MedCAT is selected in the terminal UI with no reachable service it warns before the run; if none is reachable at run time, the MedCAT step returns no annotations and the rest of the run continues.

## Notes
- Offered in the terminal UI but not pre-selected, since it needs the service.
- Entity types are the model pack's semantic types (UMLS TUIs), so they pass through rather than mapping to the canonical types.
- MedMen is the demo model, we can play with min_acc for better results.

## Validation
- Live run on a PMID returned 72 MedCAT annotations through the full pipeline.
- uv run pytest: 148 passed, 1 skipped."