### PR TITLE
Add ClinicalBERT annotator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,13 @@ dependencies = [
 flair = [
     "flair==0.15.1",
 ]
+clinicalbert = [
+    # ClinicalBERT (samrawal/bert-base-uncased_clinical-ner) is a HuggingFace
+    # transformers token-classification model; it needs transformers + a torch
+    # backend to run locally.
+    "transformers>=4.30,<5",
+    "torch>=2.0",
+]
 benchmarks = [
     # bigbio corpora ship as Hugging Face dataset scripts; datasets>=4 removed
     # script support, so pin to the 2.x/3.x line that still loads them.
@@ -24,7 +31,7 @@ benchmarks = [
     "tabulate>=0.9",
 ]
 all = [
-    "totalannotator[flair,benchmarks]",
+    "totalannotator[flair,clinicalbert,benchmarks]",
 ]
 
 [project.scripts]

--- a/src/bio_annotation/annotators/__init__.py
+++ b/src/bio_annotation/annotators/__init__.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from bio_annotation.annotators.aioner import annotate_with_aioner
 from bio_annotation.annotators.bern2 import annotate_with_bern2
+from bio_annotation.annotators.clinicalbert import annotate_with_clinicalbert
 from bio_annotation.annotators.flair import annotate_with_flair
 from bio_annotation.annotators.pubtator3 import annotate_with_pubtator3
 from bio_annotation.schemas.document import Document
@@ -26,6 +27,9 @@ def run_all_annotators(
     pubtator3_endpoint: str | None = None,
     aioner_response: Any = None,
     aioner_request_fn: Any = None,
+    clinicalbert_response: Any = None,
+    clinicalbert_request_fn: Any = None,
+    clinicalbert_pipeline: Any = None,
 ) -> dict[str, list[Annotation]]:
     results = {
         "bern2": annotate_with_bern2(
@@ -56,18 +60,32 @@ def run_all_annotators(
             response=aioner_response,
             request_fn=aioner_request_fn,
         )
+    # ClinicalBERT loads a local HuggingFace model, so only invoke it when an
+    # explicit response, request function, or loaded pipeline is supplied.
+    if (
+        clinicalbert_response is not None
+        or clinicalbert_request_fn is not None
+        or clinicalbert_pipeline is not None
+    ):
+        results["clinicalbert"] = annotate_with_clinicalbert(
+            document,
+            response=clinicalbert_response,
+            request_fn=clinicalbert_request_fn,
+            pipeline=clinicalbert_pipeline,
+        )
     return results
 
 
 def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation]:
     annotations: list[Annotation] = []
-    for source in ("bern2", "flair", "pubtator3", "aioner"):
+    for source in ("bern2", "flair", "pubtator3", "aioner", "clinicalbert"):
         annotations.extend(results.get(source, []))
     return annotations
 
 __all__ = [
     "annotate_with_aioner",
     "annotate_with_bern2",
+    "annotate_with_clinicalbert",
     "annotate_with_flair",
     "annotate_with_pubtator3",
     "flatten_annotations",

--- a/src/bio_annotation/annotators/clinicalbert.py
+++ b/src/bio_annotation/annotators/clinicalbert.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 from bio_annotation.entity_proposal.clinicalbert_proposer import (
+    CLINICALBERT_INSTALL_HINT,
     DEFAULT_CLINICALBERT_MODEL,
+    _load_clinicalbert_pipeline,
     annotate_with_clinicalbert,
     parse_clinicalbert_response,
 )
 
 __all__ = [
+    "CLINICALBERT_INSTALL_HINT",
     "DEFAULT_CLINICALBERT_MODEL",
+    "_load_clinicalbert_pipeline",
     "annotate_with_clinicalbert",
     "parse_clinicalbert_response",
 ]

--- a/src/bio_annotation/annotators/clinicalbert.py
+++ b/src/bio_annotation/annotators/clinicalbert.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from bio_annotation.entity_proposal.clinicalbert_proposer import (
+    DEFAULT_CLINICALBERT_MODEL,
+    annotate_with_clinicalbert,
+    parse_clinicalbert_response,
+)
+
+__all__ = [
+    "DEFAULT_CLINICALBERT_MODEL",
+    "annotate_with_clinicalbert",
+    "parse_clinicalbert_response",
+]

--- a/src/bio_annotation/entity_proposal/__init__.py
+++ b/src/bio_annotation/entity_proposal/__init__.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from bio_annotation.entity_proposal.aioner_proposer import annotate_with_aioner
 from bio_annotation.entity_proposal.bern2_proposer import annotate_with_bern2
+from bio_annotation.entity_proposal.clinicalbert_proposer import annotate_with_clinicalbert
 from bio_annotation.entity_proposal.flair_proposer import annotate_with_flair
 from bio_annotation.entity_proposal.pubtator3_proposer import annotate_with_pubtator3
 from bio_annotation.schemas.document import Document
@@ -26,6 +27,9 @@ def run_all_annotators(
     pubtator3_endpoint: str | None = None,
     aioner_response: Any = None,
     aioner_request_fn: Any = None,
+    clinicalbert_response: Any = None,
+    clinicalbert_request_fn: Any = None,
+    clinicalbert_pipeline: Any = None,
 ) -> dict[str, list[Annotation]]:
     """Run all configured annotator adapters and return normalized outputs."""
 
@@ -56,12 +60,24 @@ def run_all_annotators(
             response=aioner_response,
             request_fn=aioner_request_fn,
         )
+    # Only invoke ClinicalBERT when a response, request function, or pipeline is provided.
+    if (
+        clinicalbert_response is not None
+        or clinicalbert_request_fn is not None
+        or clinicalbert_pipeline is not None
+    ):
+        results["clinicalbert"] = annotate_with_clinicalbert(
+            document,
+            response=clinicalbert_response,
+            request_fn=clinicalbert_request_fn,
+            pipeline=clinicalbert_pipeline,
+        )
     return results
 
 
 def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation]:
     annotations: list[Annotation] = []
-    for source in ("bern2", "flair", "pubtator3", "aioner"):
+    for source in ("bern2", "flair", "pubtator3", "aioner", "clinicalbert"):
         annotations.extend(results.get(source, []))
     return annotations
 
@@ -69,6 +85,7 @@ def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation
 __all__ = [
     "annotate_with_aioner",
     "annotate_with_bern2",
+    "annotate_with_clinicalbert",
     "annotate_with_flair",
     "annotate_with_pubtator3",
     "flatten_annotations",

--- a/src/bio_annotation/entity_proposal/clinicalbert_proposer.py
+++ b/src/bio_annotation/entity_proposal/clinicalbert_proposer.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any, Callable, Iterable
+
+from bio_annotation.entity_proposal._shared import make_annotation
+from bio_annotation.schemas.document import Document
+from bio_annotation.schemas.entity import Annotation
+
+# i2b2-2010 clinical NER (problem / test / treatment), fine-tuned from BERT.
+DEFAULT_CLINICALBERT_MODEL = "samrawal/bert-base-uncased_clinical-ner"
+
+
+def parse_clinicalbert_response(
+    document: Document,
+    payload: Iterable[Any] | None,
+) -> list[Annotation]:
+    """Parse HuggingFace token-classification output into Annotations.
+
+    The transformers NER pipeline uses ``aggregation_strategy="first"``. The
+    clinical labels (problem / test / treatment) are kept as their own types
+    rather than mapped onto the canonical biomedical set.
+    """
+
+    if not payload:
+        return []
+
+    annotations: list[Annotation] = []
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        label = item.get("entity_group") or item.get("entity")
+        start = item.get("start")
+        end = item.get("end")
+        if isinstance(start, int) and isinstance(end, int) and 0 <= start < end:
+            span_text = document.text[start:end]
+        else:
+            span_text = item.get("word")
+            start = end = None
+        if not span_text:
+            continue
+
+        annotations.append(
+            make_annotation(
+                document=document,
+                source="clinicalbert",
+                span_text=span_text,
+                entity_type=label,
+                start=start,
+                end=end,
+                confidence=item.get("score"),
+            )
+        )
+
+    return annotations
+
+
+@lru_cache(maxsize=2)
+def _load_clinicalbert_pipeline(model: str) -> Any:
+    from transformers import pipeline
+
+    # "first" groups sub-word tokens into whole words and keeps the first
+    # sub-word's label, which is what this B-/I- tagging model needs.
+    return pipeline(
+        "ner",
+        model=model,
+        tokenizer=model,
+        aggregation_strategy="first",
+    )
+
+
+def annotate_with_clinicalbert(
+    document: Document,
+    *,
+    response: Any = None,
+    request_fn: Callable[[Document], Any] | None = None,
+    pipeline: Any = None,
+    model: str | None = None,
+    pipeline_loader: Callable[[str], Any] | None = None,
+) -> list[Annotation]:
+    payload = response
+    if payload is None and request_fn is not None:
+        payload = request_fn(document)
+    if payload is None:
+        if pipeline is None and model:
+            loader = pipeline_loader or _load_clinicalbert_pipeline
+            pipeline = loader(model)
+        if pipeline is not None:
+            payload = pipeline(document.text)
+    return parse_clinicalbert_response(document, payload)

--- a/src/bio_annotation/entity_proposal/clinicalbert_proposer.py
+++ b/src/bio_annotation/entity_proposal/clinicalbert_proposer.py
@@ -10,6 +10,27 @@ from bio_annotation.schemas.entity import Annotation
 # i2b2-2010 clinical NER (problem / test / treatment), fine-tuned from BERT.
 DEFAULT_CLINICALBERT_MODEL = "samrawal/bert-base-uncased_clinical-ner"
 
+CLINICALBERT_INSTALL_HINT = (
+    "The ClinicalBERT annotator requires the optional Hugging Face dependencies. "
+    "Install them with: uv sync --extra clinicalbert"
+)
+
+# The model can emit spans with leading/trailing punctuation; trim those boundary
+# characters off the edges while keeping offsets correct. Hyphen and slash are
+# excluded since they occur inside clinical terms (e.g. "mg/dL", "5-HT").
+_BOUNDARY_CHARS = " \t\n\r\f\v.,;:!?()[]{}\"'"
+
+
+def _trim_boundary(
+    text: str, start: int | None, end: int | None
+) -> tuple[str, int | None, int | None]:
+    inner = text.strip(_BOUNDARY_CHARS)
+    if not inner or not isinstance(start, int) or not isinstance(end, int):
+        return inner, start, end
+    lead = len(text) - len(text.lstrip(_BOUNDARY_CHARS))
+    new_start = start + lead
+    return inner, new_start, new_start + len(inner)
+
 
 def parse_clinicalbert_response(
     document: Document,
@@ -39,6 +60,9 @@ def parse_clinicalbert_response(
             start = end = None
         if not span_text:
             continue
+        span_text, start, end = _trim_boundary(span_text, start, end)
+        if not span_text:
+            continue
 
         annotations.append(
             make_annotation(
@@ -57,7 +81,10 @@ def parse_clinicalbert_response(
 
 @lru_cache(maxsize=2)
 def _load_clinicalbert_pipeline(model: str) -> Any:
-    from transformers import pipeline
+    try:
+        from transformers import pipeline
+    except ImportError as exc:
+        raise RuntimeError(CLINICALBERT_INSTALL_HINT) from exc
 
     # "first" groups sub-word tokens into whole words and keeps the first
     # sub-word's label, which is what this B-/I- tagging model needs.

--- a/src/bio_annotation/entity_types.py
+++ b/src/bio_annotation/entity_types.py
@@ -56,6 +56,13 @@ ANNOTATOR_ENTITY_TYPE_SPECS: tuple[AnnotatorEntityTypeSpec, ...] = (
     AnnotatorEntityTypeSpec("aioner", "AIONER", "Species", "species", ()),
     AnnotatorEntityTypeSpec("aioner", "AIONER", "Variant", "variant", ()),
     AnnotatorEntityTypeSpec("aioner", "AIONER", "CellLine", "cell_line", ()),
+    # ClinicalBERT (i2b2) emits problem / test / treatment. These are clinical
+    # categories with no exact match in the canonical biomedical set (problem is
+    # broader than disease, treatment broader than drug), so they are kept as their
+    # own types rather than forced into disease/drug.
+    AnnotatorEntityTypeSpec("clinicalbert", "ClinicalBERT", "problem", "problem", ()),
+    AnnotatorEntityTypeSpec("clinicalbert", "ClinicalBERT", "test", "test", ()),
+    AnnotatorEntityTypeSpec("clinicalbert", "ClinicalBERT", "treatment", "treatment", ()),
 )
 
 
@@ -146,6 +153,22 @@ ANNOTATOR_CAPABILITIES: dict[str, AnnotatorCapability] = {
             spec.canonical_entity_type: spec.database_ids
             for spec in ANNOTATOR_ENTITY_TYPE_SPECS
             if spec.annotator == "aioner"
+        },
+        normalization_fields=(),
+    ),
+    "clinicalbert": AnnotatorCapability(
+        label="ClinicalBERT",
+        tasks=("NER",),
+        entity_types=tuple(
+            spec.canonical_entity_type
+            for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+            if spec.annotator == "clinicalbert"
+        ),
+        normalization_status="not_returned",
+        normalization_databases={
+            spec.canonical_entity_type: spec.database_ids
+            for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+            if spec.annotator == "clinicalbert"
         },
         normalization_fields=(),
     ),

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -12,7 +12,9 @@ from typing import Any, Callable
 from bio_annotation.annotators.aioner import annotate_with_aioner
 from bio_annotation.annotators.bern2 import annotate_with_bern2
 from bio_annotation.annotators.clinicalbert import (
+    CLINICALBERT_INSTALL_HINT,
     DEFAULT_CLINICALBERT_MODEL,
+    _load_clinicalbert_pipeline,
     annotate_with_clinicalbert,
 )
 from bio_annotation.annotators.flair import annotate_with_flair
@@ -33,10 +35,6 @@ SUPPORTED_ANNOTATORS = {"bern2", "flair", "pubtator3", "aioner", "clinicalbert"}
 FLAIR_INSTALL_HINT = (
     "The Flair annotator requires the optional Flair dependency. "
     "Install it with: uv sync --extra flair"
-)
-CLINICALBERT_INSTALL_HINT = (
-    "The ClinicalBERT annotator requires the optional Hugging Face dependencies. "
-    "Install them with: uv sync --extra clinicalbert"
 )
 logger = logging.getLogger(__name__)
 
@@ -968,7 +966,7 @@ def validate_optional_annotator_dependencies(
     if (
         "clinicalbert" in config.annotators
         and clinicalbert_responses_by_document is None
-        and find_spec("transformers") is None
+        and (find_spec("transformers") is None or find_spec("torch") is None)
     ):
         raise ValueError(CLINICALBERT_INSTALL_HINT)
 
@@ -1034,21 +1032,6 @@ def _read_clinicalbert_options(settings: dict[str, object]) -> dict[str, Any]:
         if isinstance(model, str) and model.strip()
         else DEFAULT_CLINICALBERT_MODEL,
     }
-
-
-def _load_clinicalbert_pipeline(model: str) -> Any:
-    try:
-        from transformers import pipeline
-    except ImportError as exc:
-        raise RuntimeError(CLINICALBERT_INSTALL_HINT) from exc
-
-    # "first" groups sub-word tokens into whole words (see clinicalbert_proposer).
-    return pipeline(
-        "ner",
-        model=model,
-        tokenizer=model,
-        aggregation_strategy="first",
-    )
 
 
 def _read_pubtator3_options(settings: dict[str, object]) -> dict[str, Any]:

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -11,6 +11,10 @@ from typing import Any, Callable
 
 from bio_annotation.annotators.aioner import annotate_with_aioner
 from bio_annotation.annotators.bern2 import annotate_with_bern2
+from bio_annotation.annotators.clinicalbert import (
+    DEFAULT_CLINICALBERT_MODEL,
+    annotate_with_clinicalbert,
+)
 from bio_annotation.annotators.flair import annotate_with_flair
 from bio_annotation.annotators.pubtator3 import annotate_with_pubtator3
 from bio_annotation.entity_types import normalize_entity_type
@@ -25,10 +29,14 @@ from bio_annotation.preprocessing.document_loader import (
 from bio_annotation.schemas.document import Document
 from bio_annotation.schemas.entity import Annotation
 
-SUPPORTED_ANNOTATORS = {"bern2", "flair", "pubtator3", "aioner"}
+SUPPORTED_ANNOTATORS = {"bern2", "flair", "pubtator3", "aioner", "clinicalbert"}
 FLAIR_INSTALL_HINT = (
     "The Flair annotator requires the optional Flair dependency. "
     "Install it with: uv sync --extra flair"
+)
+CLINICALBERT_INSTALL_HINT = (
+    "The ClinicalBERT annotator requires the optional Hugging Face dependencies. "
+    "Install them with: uv sync --extra clinicalbert"
 )
 logger = logging.getLogger(__name__)
 
@@ -42,11 +50,13 @@ def run_pipeline_from_config(
     pubtator3_request_fn: Callable[[Document], Any] | None = None,
     flair_spans_by_document: dict[str, list[Any]] | None = None,
     aioner_request_fn: Callable[[Document], Any] | None = None,
+    clinicalbert_responses_by_document: dict[str, list[Any]] | None = None,
 ) -> dict[str, Any]:
     config = load_pipeline_config(config_path)
     validate_optional_annotator_dependencies(
         config,
         flair_spans_by_document=flair_spans_by_document,
+        clinicalbert_responses_by_document=clinicalbert_responses_by_document,
     )
     if pmid_fetcher is not None and config.input_mode == "pmids":
         documents = load_documents_from_pmids(
@@ -74,6 +84,7 @@ def run_pipeline_from_config(
         pubtator3_request_fn=pubtator3_request_fn,
         flair_spans_by_document=flair_spans_by_document,
         aioner_request_fn=aioner_request_fn,
+        clinicalbert_responses_by_document=clinicalbert_responses_by_document,
     )
     if config.output_path is not None:
         actual_output_path = timestamped_output_path(config.output_path)
@@ -94,6 +105,7 @@ def build_pipeline_output(
     pubtator3_request_fn: Callable[[Document], Any] | None = None,
     flair_spans_by_document: dict[str, list[Any]] | None = None,
     aioner_request_fn: Callable[[Document], Any] | None = None,
+    clinicalbert_responses_by_document: dict[str, list[Any]] | None = None,
 ) -> dict[str, Any]:
     enabled_annotators = list(config.annotators)
     annotator_settings = dict(config.annotator_settings)
@@ -104,6 +116,7 @@ def build_pipeline_output(
     pubtator3_options = _read_pubtator3_options(annotator_settings.get("pubtator3", {}))
     flair_options = _read_flair_options(annotator_settings.get("flair", {}))
     aioner_options = _read_aioner_options(annotator_settings.get("aioner", {}))
+    clinicalbert_options = _read_clinicalbert_options(annotator_settings.get("clinicalbert", {}))
 
     flair_tagger = None
     if "flair" in enabled_annotators and flair_spans_by_document is None:
@@ -111,6 +124,12 @@ def build_pipeline_output(
             flair_tagger = _load_flair_tagger(flair_options["model"] or "hunflair2")
         except Exception as exc:
             logger.warning("flair unavailable: %s", exc)
+    clinicalbert_pipeline = None
+    if "clinicalbert" in enabled_annotators and clinicalbert_responses_by_document is None:
+        try:
+            clinicalbert_pipeline = _load_clinicalbert_pipeline(clinicalbert_options["model"])
+        except Exception as exc:
+            logger.warning("clinicalbert unavailable: %s", exc)
     document_annotations: list[dict[str, Any]] = []
     annotations_output: list[dict[str, Any]] = []
     keyword_output: list[dict[str, Any]] = []
@@ -139,6 +158,13 @@ def build_pipeline_output(
                 else None
             ),
             flair_tagger=flair_tagger,
+            clinicalbert_response=(
+                clinicalbert_responses_by_document.get(document.document_id)
+                if clinicalbert_responses_by_document is not None
+                else None
+            ),
+            clinicalbert_pipeline=clinicalbert_pipeline,
+            clinicalbert_options=clinicalbert_options,
         )
         all_statuses.extend(statuses)
 
@@ -400,6 +426,9 @@ def run_selected_annotators(
     flair_spans: list[Any] | None = None,
     flair_tagger: Any = None,
     flair_options: dict[str, Any] | None = None,
+    clinicalbert_response: Any = None,
+    clinicalbert_pipeline: Any = None,
+    clinicalbert_options: dict[str, Any] | None = None,
 ) -> dict[str, list[Annotation]]:
     results, _ = run_selected_annotators_with_status(
         document,
@@ -413,6 +442,9 @@ def run_selected_annotators(
         flair_spans=flair_spans,
         flair_tagger=flair_tagger,
         flair_options=flair_options,
+        clinicalbert_response=clinicalbert_response,
+        clinicalbert_pipeline=clinicalbert_pipeline,
+        clinicalbert_options=clinicalbert_options,
     )
     return results
 
@@ -430,6 +462,9 @@ def run_selected_annotators_with_status(
     flair_spans: list[Any] | None = None,
     flair_tagger: Any = None,
     flair_options: dict[str, Any] | None = None,
+    clinicalbert_response: Any = None,
+    clinicalbert_pipeline: Any = None,
+    clinicalbert_options: dict[str, Any] | None = None,
 ) -> tuple[dict[str, list[Annotation]], list[dict[str, Any]]]:
     results: dict[str, list[Annotation]] = {}
     statuses: list[dict[str, Any]] = []
@@ -515,6 +550,13 @@ def run_selected_annotators_with_status(
                     if aioner_options
                     else 600,
                 )
+            elif annotator == "clinicalbert":
+                results[annotator] = annotate_with_clinicalbert(
+                    document,
+                    response=clinicalbert_response,
+                    pipeline=clinicalbert_pipeline,
+                    model=clinicalbert_options.get("model") if clinicalbert_options else None,
+                )
             else:
                 raise ValueError(f"Unsupported annotator: {annotator}")
         except Exception as exc:
@@ -551,7 +593,7 @@ def run_selected_annotators_with_status(
 
 def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation]:
     annotations: list[Annotation] = []
-    for source in ("bern2", "flair", "pubtator3", "aioner"):
+    for source in ("bern2", "flair", "pubtator3", "aioner", "clinicalbert"):
         annotations.extend(results.get(source, []))
     return annotations
 
@@ -753,6 +795,11 @@ def _no_annotations_reason(annotator: str) -> str:
             "(tools/aioner/setup.sh) and annotators.aioner.repo/model are set, "
             "or it found no entities."
         )
+    if annotator == "clinicalbert":
+        return (
+            "No annotations returned. The ClinicalBERT model may be unavailable/not "
+            "downloaded (uv sync --extra clinicalbert), or it found no entities."
+        )
     return "No annotations returned."
 
 
@@ -910,13 +957,20 @@ def validate_optional_annotator_dependencies(
     config: PipelineConfig,
     *,
     flair_spans_by_document: dict[str, list[Any]] | None = None,
+    clinicalbert_responses_by_document: dict[str, list[Any]] | None = None,
 ) -> None:
-    if "flair" not in config.annotators:
-        return
-    if flair_spans_by_document is not None:
-        return
-    if find_spec("flair") is None:
+    if (
+        "flair" in config.annotators
+        and flair_spans_by_document is None
+        and find_spec("flair") is None
+    ):
         raise ValueError(FLAIR_INSTALL_HINT)
+    if (
+        "clinicalbert" in config.annotators
+        and clinicalbert_responses_by_document is None
+        and find_spec("transformers") is None
+    ):
+        raise ValueError(CLINICALBERT_INSTALL_HINT)
 
 
 def _read_bern2_options(settings: dict[str, object]) -> dict[str, Any]:
@@ -971,6 +1025,30 @@ def _load_flair_tagger(model: str) -> Any:
 
     flair.logger.setLevel(logging.WARNING)
     return Classifier.load(model)
+
+
+def _read_clinicalbert_options(settings: dict[str, object]) -> dict[str, Any]:
+    model = settings.get("model")
+    return {
+        "model": model.strip()
+        if isinstance(model, str) and model.strip()
+        else DEFAULT_CLINICALBERT_MODEL,
+    }
+
+
+def _load_clinicalbert_pipeline(model: str) -> Any:
+    try:
+        from transformers import pipeline
+    except ImportError as exc:
+        raise RuntimeError(CLINICALBERT_INSTALL_HINT) from exc
+
+    # "first" groups sub-word tokens into whole words (see clinicalbert_proposer).
+    return pipeline(
+        "ner",
+        model=model,
+        tokenizer=model,
+        aggregation_strategy="first",
+    )
 
 
 def _read_pubtator3_options(settings: dict[str, object]) -> dict[str, Any]:

--- a/src/bio_annotation/terminal_ui.py
+++ b/src/bio_annotation/terminal_ui.py
@@ -14,6 +14,7 @@ from bio_annotation.entity_proposal.aioner_proposer import (
     DEFAULT_AIONER_PROJECT,
 )
 from bio_annotation.entity_proposal.bern2_proposer import DEFAULT_BERN2_API_URL
+from bio_annotation.entity_proposal.clinicalbert_proposer import DEFAULT_CLINICALBERT_MODEL
 from bio_annotation.entity_types import (
     ANNOTATOR_CHOICES,
     ANNOTATOR_DISPLAY_NAMES,
@@ -139,9 +140,11 @@ def collect_terminal_ui_answers(*, input_fn: InputFn, output_fn: OutputFn) -> Te
         output_fn=output_fn,
         title="Choose annotators",
         choices=ANNOTATOR_CHOICES,
-        # AIONER requires a separate environment + downloaded models, so it is
-        # offered as a choice but not pre-selected by default.
-        default_values=[value for value, _ in ANNOTATOR_CHOICES if value != "aioner"],
+        # AIONER and ClinicalBERT need extra setup (separate env / model download),
+        # so they are offered as choices but not pre-selected by default.
+        default_values=[
+            value for value, _ in ANNOTATOR_CHOICES if value not in {"aioner", "clinicalbert"}
+        ],
         validate_values=_validate_selected_annotators,
     )
     entity_types = _prompt_entity_types(input_fn=input_fn, output_fn=output_fn, annotators=annotators)
@@ -211,6 +214,8 @@ def build_terminal_ui_config_text(answers: TerminalUIAnswers, paths: RunPaths) -
     if "aioner" in answers.annotators:
         aioner_repo, aioner_model = aioner_config_paths()
         lines += ["", "[annotators.aioner]", 'runtime = "local_subprocess"', f"repo = {_toml_string(aioner_repo)}", f"model = {_toml_string(aioner_model)}", f"entity = {_toml_string(DEFAULT_AIONER_ENTITY)}", f"project = {_toml_string(DEFAULT_AIONER_PROJECT)}"]
+    if "clinicalbert" in answers.annotators:
+        lines += ["", "[annotators.clinicalbert]", 'runtime = "local_model"', f"model = {_toml_string(DEFAULT_CLINICALBERT_MODEL)}"]
     lines += ["", "[filters]", f"entity_types = {_toml_string_list(answers.entity_types)}", "", "[output]", f"path = {_toml_string(str(paths.results_path))}", ""]
     return "\n".join(lines)
 
@@ -257,9 +262,26 @@ def find_unsupported_entity_types(annotators: list[str], entity_types: list[str]
     return {a: missing for a in annotators if (missing := [e for e in entity_types if e not in ANNOTATOR_ENTITY_TYPES.get(a, set())])}
 
 
+def _entity_type_choices_for(annotators: list[str]) -> tuple[tuple[str, str], ...]:
+    # Offer the entity types the selected annotators actually produce, so a
+    # clinical annotator like ClinicalBERT adds its own categories (problem /
+    # test / treatment) to the menu. Canonical types stay first, in their usual
+    # order; extra annotator-specific types follow.
+    available: set[str] = set()
+    for annotator in annotators:
+        available |= ANNOTATOR_ENTITY_TYPES.get(annotator, set())
+    if not available:
+        return ENTITY_TYPE_CHOICES
+    canonical_order = [value for value, _ in ENTITY_TYPE_CHOICES]
+    ordered = [value for value in canonical_order if value in available]
+    ordered.extend(sorted(available - set(canonical_order)))
+    return tuple((value, _entity_type_label(value)) for value in ordered)
+
+
 def _prompt_entity_types(*, input_fn: InputFn, output_fn: OutputFn, annotators: list[str]) -> list[str]:
+    choices = _entity_type_choices_for(annotators)
     while True:
-        entity_types = _prompt_multi_choice(input_fn=input_fn, output_fn=output_fn, title="Choose entity types to include, or press Enter for all entity types", choices=ENTITY_TYPE_CHOICES, default_values=[], allow_empty=True)
+        entity_types = _prompt_multi_choice(input_fn=input_fn, output_fn=output_fn, title="Choose entity types to include, or press Enter for all entity types", choices=choices, default_values=[], allow_empty=True)
         unsupported = find_unsupported_entity_types(annotators, entity_types)
         if not unsupported:
             return entity_types
@@ -385,7 +407,10 @@ def _annotator_label(annotator: str) -> str:
 
 
 def _entity_type_label(entity_type: str) -> str:
-    return ENTITY_TYPE_DISPLAY_NAMES.get(entity_type, entity_type)
+    return ENTITY_TYPE_DISPLAY_NAMES.get(
+        entity_type,
+        entity_type.replace("_", " ").capitalize(),
+    )
 
 
 def _toml_string(value: str) -> str:

--- a/tests/test_annotators.py
+++ b/tests/test_annotators.py
@@ -15,6 +15,10 @@ from bio_annotation.annotators.aioner import (
     build_aioner_pubtator_input,
     call_aioner,
 )
+from bio_annotation.annotators.clinicalbert import (
+    DEFAULT_CLINICALBERT_MODEL,
+    annotate_with_clinicalbert,
+)
 from bio_annotation.annotators.bern2 import annotate_with_bern2, call_bern2
 from bio_annotation.annotators.flair import annotate_with_flair
 from bio_annotation.annotators.pubtator3 import annotate_with_pubtator3, call_pubtator3
@@ -540,6 +544,74 @@ def test_aioner_call_requires_configuration(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="AIONER repo path is not configured"):
         call_aioner(document)
+
+
+def test_clinicalbert_adapter_parses_pipeline_output_and_normalizes_types() -> None:
+    document = sample_document()
+    # HuggingFace token-classification output. The clinical labels problem / test
+    # / treatment are kept as their own types. Span text is sliced from
+    # document.text, so the model's "word" field is ignored.
+    response = [
+        {"entity_group": "problem", "score": 0.99, "word": "oblastoma", "start": 15, "end": 27},
+        {"entity_group": "treatment", "score": 0.95, "word": "PTEN", "start": 0, "end": 4},
+        {"entity_group": "test", "score": 0.80, "word": "x", "start": 49, "end": 59},
+    ]
+
+    annotations = annotate_with_clinicalbert(document, response=response)
+
+    assert len(annotations) == 3
+    assert all(annotation.source == "clinicalbert" for annotation in annotations)
+    assert annotations[0].entity_type == "problem"
+    assert annotations[0].span_text == "glioblastoma"
+    assert annotations[0].start == 15
+    assert annotations[0].end == 27
+    assert annotations[1].entity_type == "treatment"
+    assert annotations[2].entity_type == "test"
+    assert all(annotation.canonical_id is None for annotation in annotations)
+
+
+def test_clinicalbert_adapter_uses_request_fn() -> None:
+    document = sample_document()
+    calls: list[Document] = []
+
+    def fake_request(doc: Document) -> list[dict[str, object]]:
+        calls.append(doc)
+        return [
+            {"entity_group": "problem", "score": 0.9, "word": "glioblastoma", "start": 15, "end": 27}
+        ]
+
+    annotations = annotate_with_clinicalbert(document, request_fn=fake_request)
+
+    assert calls == [document]
+    assert len(annotations) == 1
+    assert annotations[0].entity_type == "problem"
+
+
+def test_clinicalbert_adapter_loads_configured_model() -> None:
+    document = sample_document()
+    loaded_models: list[str] = []
+
+    class FakePipeline:
+        def __call__(self, text: str) -> list[dict[str, object]]:
+            assert text == document.text
+            return [
+                {"entity_group": "treatment", "score": 0.88, "word": "PTEN", "start": 0, "end": 4}
+            ]
+
+    def fake_loader(model: str) -> FakePipeline:
+        loaded_models.append(model)
+        return FakePipeline()
+
+    annotations = annotate_with_clinicalbert(
+        document,
+        model=DEFAULT_CLINICALBERT_MODEL,
+        pipeline_loader=fake_loader,
+    )
+
+    assert loaded_models == [DEFAULT_CLINICALBERT_MODEL]
+    assert len(annotations) == 1
+    assert annotations[0].source == "clinicalbert"
+    assert annotations[0].entity_type == "treatment"
 
 
 def test_run_all_annotators_returns_consistent_result_map() -> None:

--- a/tests/test_terminal_ui.py
+++ b/tests/test_terminal_ui.py
@@ -206,10 +206,10 @@ def test_run_terminal_annotation_ui_writes_reproducible_plain_text_run(tmp_path)
     assert manifest["document_count"] == 2
     assert manifest["annotation_count"] == 2
     assert payload["document_count"] == 2
-    assert "Run complete" in messages
-    assert f"Keywords TSV: {output_dir / 'results.keywords.tsv'}" in messages
-    assert f"Keyword evidence TSV: {output_dir / 'results.keyword_annotator_evidence.tsv'}" in messages
-    assert f"Annotations TSV: {output_dir / 'results.annotations.tsv'}" in messages
+    assert any("Run complete" in message for message in messages)
+    assert any("Keywords TSV" in message for message in messages)
+    assert any("Keyword evidence TSV" in message for message in messages)
+    assert any("Annotations TSV" in message for message in messages)
 
 
 def test_run_terminal_annotation_ui_uses_one_raw_text_line_per_document(tmp_path) -> None:
@@ -371,6 +371,6 @@ def test_run_terminal_annotation_ui_warns_for_unsupported_entity_types(tmp_path)
         pipeline_run_fn=fake_pipeline_run,
     )
 
-    assert "Entity type compatibility warning:" in messages
+    assert any("Entity type compatibility warning" in message for message in messages)
     assert any("Flair / HunFlair does not produce: Variant / mutation" in message for message in messages)
     assert not any("BERN2 does not produce" in message for message in messages)

--- a/uv.lock
+++ b/uv.lock
@@ -2464,11 +2464,17 @@ all = [
     { name = "flair" },
     { name = "pandas" },
     { name = "tabulate" },
+    { name = "torch" },
+    { name = "transformers" },
 ]
 benchmarks = [
     { name = "datasets" },
     { name = "pandas" },
     { name = "tabulate" },
+]
+clinicalbert = [
+    { name = "torch" },
+    { name = "transformers" },
 ]
 flair = [
     { name = "flair" },
@@ -2486,9 +2492,11 @@ requires-dist = [
     { name = "matplotlib", specifier = ">=3.8" },
     { name = "pandas", marker = "extra == 'benchmarks'", specifier = ">=2.0" },
     { name = "tabulate", marker = "extra == 'benchmarks'", specifier = ">=0.9" },
-    { name = "totalannotator", extras = ["flair", "benchmarks"], marker = "extra == 'all'" },
+    { name = "torch", marker = "extra == 'clinicalbert'", specifier = ">=2.0" },
+    { name = "totalannotator", extras = ["flair", "clinicalbert", "benchmarks"], marker = "extra == 'all'" },
+    { name = "transformers", marker = "extra == 'clinicalbert'", specifier = ">=4.30,<5" },
 ]
-provides-extras = ["flair", "benchmarks", "all"]
+provides-extras = ["flair", "clinicalbert", "benchmarks", "all"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.0" }]


### PR DESCRIPTION
## Summary
Local HuggingFace transformers NER (samrawal/bert-base-uncased_clinical-ner, i2b2 problem/test/treatment), wired into the shared pipeline so it runs from run-config and the terminal UI. The clinical labels problem/test/treatment are kept as their own types, and the entity-type prompt offers them when ClinicalBERT is selected. NER-only. Needs the [clinicalbert] extra (transformers + torch)


## Validation
- Unit tests for parsing, request_fn, and model loading; full suite passes (147 passed, 1 skipped).
- Live run on a PMID via run-config produced problem / test / treatment annotations.

## Notes
- The i2b2 model is tuned for clinical notes, so on dense molecular abstracts it can be noisy. A future optional min_score filter (mirroring MedCAT's min_acc) can trim low-confidence spans.
