### PR TITLE
Totalannotator rich UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TotalAnnotator
 
-TotalAnnotator is a terminal-first biomedical annotation tool for turning PubMed IDs or local text into reproducible annotation runs.
+TotalAnnotator is a biomedical annotation tool for turning PubMed IDs or local text into reproducible annotation runs.
 
 The main workflow is:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "matplotlib>=3.8",
+    "rich>=13.7",
 ]
 
 [project.optional-dependencies]

--- a/src/bio_annotation/terminal_theme.py
+++ b/src/bio_annotation/terminal_theme.py
@@ -1,25 +1,50 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from io import StringIO
 from pathlib import Path
 from typing import Any
 
 from rich import box
+from rich.align import Align
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
+from rich.theme import Theme
 from rich.text import Text
 
 
 THEME_WIDTH = 100
+TOTALANNOTATOR_THEME = Theme(
+    {
+        "brand": "bold cyan",
+        "accent": "bold magenta",
+        "muted": "bright_black",
+        "panel.border": "bright_cyan",
+        "panel.title": "bold cyan",
+        "table.header": "bold cyan",
+        "table.title": "bold magenta",
+        "field": "bold cyan",
+        "ok": "bold green",
+        "warning": "bold yellow",
+        "path": "bright_blue",
+    }
+)
 
 
 def render_lines(renderable: Any) -> list[str]:
     """Render a Rich object to plain terminal lines for the existing output_fn API."""
 
-    console = Console(width=THEME_WIDTH, color_system=None, force_terminal=False, record=True)
+    buffer = StringIO()
+    console = Console(
+        width=THEME_WIDTH,
+        color_system="truecolor",
+        force_terminal=True,
+        file=buffer,
+        theme=TOTALANNOTATOR_THEME,
+    )
     console.print(renderable)
-    return console.export_text(clear=True).rstrip("\n").splitlines()
+    return buffer.getvalue().rstrip("\n").splitlines()
 
 
 def emit(output_fn, lines: Iterable[str]) -> None:
@@ -28,18 +53,37 @@ def emit(output_fn, lines: Iterable[str]) -> None:
 
 
 def banner_lines() -> list[str]:
-    title = Text("TotalAnnotator", justify="center", style="bold")
-    subtitle = Text("Biomedical entity annotation cockpit", justify="center")
+    title = Text("TotalAnnotator", justify="center", style="brand")
+    subtitle = Text("Biomedical entity annotation workspace", justify="center", style="muted")
     body = Text.assemble(title, "\n", subtitle)
-    return render_lines(Panel(body, box=box.ROUNDED, padding=(1, 2)))
+    return render_lines(
+        Panel(
+            Align.center(body),
+            box=box.ROUNDED,
+            border_style="panel.border",
+            padding=(1, 2),
+        )
+    )
 
 
 def help_lines() -> list[str]:
     return render_lines(
         Panel(
-            "Choose an input source, annotators, and entity filters. "
-            "Each run writes a reproducible config, JSON results, TSV review tables, and a manifest.",
+            Text.assemble(
+                ("Choose an input source, annotators, and entity filters.\n", "muted"),
+                ("Each run writes ", "muted"),
+                ("config", "field"),
+                (", ", "muted"),
+                ("JSON", "field"),
+                (", ", "muted"),
+                ("TSV review tables", "field"),
+                (", and a ", "muted"),
+                ("manifest", "field"),
+                (".", "muted"),
+            ),
             title="Workflow",
+            title_align="left",
+            border_style="panel.border",
             box=box.ROUNDED,
             padding=(0, 1),
         )
@@ -47,13 +91,21 @@ def help_lines() -> list[str]:
 
 
 def choice_lines(title: str, choices: tuple[tuple[str, str], ...], *, default_indexes: list[int] | None = None) -> list[str]:
-    table = Table(title=title, box=box.SIMPLE_HEAVY, show_header=True, header_style="bold")
-    table.add_column("#", justify="right", no_wrap=True)
+    table = Table(
+        title=title,
+        box=box.ROUNDED,
+        show_header=True,
+        header_style="table.header",
+        title_style="table.title",
+        border_style="panel.border",
+        pad_edge=True,
+    )
+    table.add_column("#", justify="right", no_wrap=True, style="accent")
     table.add_column("Option")
-    table.add_column("Default", justify="center", no_wrap=True)
+    table.add_column("Default", justify="center", no_wrap=True, style="ok")
     defaults = set(default_indexes or [])
     for index, (_, label) in enumerate(choices, start=1):
-        table.add_row(str(index), label, "yes" if index in defaults else "")
+        table.add_row(str(index), label, "default" if index in defaults else "")
     return render_lines(table)
 
 
@@ -62,6 +114,8 @@ def warning_lines(title: str, messages: Iterable[str]) -> list[str]:
         Panel(
             "\n".join(messages),
             title=title,
+            title_align="left",
+            border_style="warning",
             box=box.ROUNDED,
             padding=(0, 1),
         )
@@ -69,8 +123,14 @@ def warning_lines(title: str, messages: Iterable[str]) -> list[str]:
 
 
 def run_plan_lines(*, input_mode: str, annotators: list[str], entity_types: list[str]) -> list[str]:
-    table = Table(title="Run plan", box=box.SIMPLE_HEAVY, show_header=False)
-    table.add_column("Field", style="bold")
+    table = Table(
+        title="Run plan",
+        box=box.ROUNDED,
+        show_header=False,
+        title_style="table.title",
+        border_style="panel.border",
+    )
+    table.add_column("Field", style="field")
     table.add_column("Value")
     table.add_row("Input", input_mode)
     table.add_row("Annotators", ", ".join(annotators) or "all")
@@ -79,8 +139,14 @@ def run_plan_lines(*, input_mode: str, annotators: list[str], entity_types: list
 
 
 def run_summary_lines(*, document_count: int, annotation_count: int, results_path: Path, tsv_paths: dict[str, Path], config_path: Path, manifest_path: Path) -> list[str]:
-    table = Table(title="Run complete", box=box.ROUNDED, show_header=False)
-    table.add_column("Item", style="bold")
+    table = Table(
+        title="Run complete",
+        box=box.ROUNDED,
+        show_header=False,
+        title_style="table.title",
+        border_style="ok",
+    )
+    table.add_column("Item", style="field")
     table.add_column("Value")
     table.add_row("Documents", str(document_count))
     table.add_row("Annotations", str(annotation_count))

--- a/src/bio_annotation/terminal_theme.py
+++ b/src/bio_annotation/terminal_theme.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+
+THEME_WIDTH = 100
+
+
+def render_lines(renderable: Any) -> list[str]:
+    """Render a Rich object to plain terminal lines for the existing output_fn API."""
+
+    console = Console(width=THEME_WIDTH, color_system=None, force_terminal=False, record=True)
+    console.print(renderable)
+    return console.export_text(clear=True).rstrip("\n").splitlines()
+
+
+def emit(output_fn, lines: Iterable[str]) -> None:
+    for line in lines:
+        output_fn(line)
+
+
+def banner_lines() -> list[str]:
+    title = Text("TotalAnnotator", justify="center", style="bold")
+    subtitle = Text("Biomedical entity annotation cockpit", justify="center")
+    body = Text.assemble(title, "\n", subtitle)
+    return render_lines(Panel(body, box=box.ROUNDED, padding=(1, 2)))
+
+
+def help_lines() -> list[str]:
+    return render_lines(
+        Panel(
+            "Choose an input source, annotators, and entity filters. "
+            "Each run writes a reproducible config, JSON results, TSV review tables, and a manifest.",
+            title="Workflow",
+            box=box.ROUNDED,
+            padding=(0, 1),
+        )
+    )
+
+
+def choice_lines(title: str, choices: tuple[tuple[str, str], ...], *, default_indexes: list[int] | None = None) -> list[str]:
+    table = Table(title=title, box=box.SIMPLE_HEAVY, show_header=True, header_style="bold")
+    table.add_column("#", justify="right", no_wrap=True)
+    table.add_column("Option")
+    table.add_column("Default", justify="center", no_wrap=True)
+    defaults = set(default_indexes or [])
+    for index, (_, label) in enumerate(choices, start=1):
+        table.add_row(str(index), label, "yes" if index in defaults else "")
+    return render_lines(table)
+
+
+def warning_lines(title: str, messages: Iterable[str]) -> list[str]:
+    return render_lines(
+        Panel(
+            "\n".join(messages),
+            title=title,
+            box=box.ROUNDED,
+            padding=(0, 1),
+        )
+    )
+
+
+def run_plan_lines(*, input_mode: str, annotators: list[str], entity_types: list[str]) -> list[str]:
+    table = Table(title="Run plan", box=box.SIMPLE_HEAVY, show_header=False)
+    table.add_column("Field", style="bold")
+    table.add_column("Value")
+    table.add_row("Input", input_mode)
+    table.add_row("Annotators", ", ".join(annotators) or "all")
+    table.add_row("Entity filters", ", ".join(entity_types) if entity_types else "all entity types")
+    return render_lines(table)
+
+
+def run_summary_lines(*, document_count: int, annotation_count: int, results_path: Path, tsv_paths: dict[str, Path], config_path: Path, manifest_path: Path) -> list[str]:
+    table = Table(title="Run complete", box=box.ROUNDED, show_header=False)
+    table.add_column("Item", style="bold")
+    table.add_column("Value")
+    table.add_row("Documents", str(document_count))
+    table.add_row("Annotations", str(annotation_count))
+    table.add_row("Results JSON", str(results_path))
+    for label, path in tsv_paths.items():
+        table.add_row(label, str(path))
+    table.add_row("Config", str(config_path))
+    table.add_row("Manifest", str(manifest_path))
+    return render_lines(table)

--- a/src/bio_annotation/terminal_theme.py
+++ b/src/bio_annotation/terminal_theme.py
@@ -19,7 +19,7 @@ TOTALANNOTATOR_THEME = Theme(
     {
         "brand": "bold cyan",
         "accent": "bold magenta",
-        "muted": "bright_black",
+        "muted": "cyan",
         "panel.border": "bright_cyan",
         "panel.title": "bold cyan",
         "table.header": "bold cyan",

--- a/src/bio_annotation/terminal_ui.py
+++ b/src/bio_annotation/terminal_ui.py
@@ -191,7 +191,7 @@ def collect_terminal_ui_answers(*, input_fn: InputFn, output_fn: OutputFn) -> Te
     annotators = _prompt_multi_choice(
         input_fn=input_fn,
         output_fn=output_fn,
-        title="Choose annotators",
+        title="Choose annotators, or press Enter for default annotators",
         choices=ANNOTATOR_CHOICES,
         # AIONER needs a separate environment + models, apollo/d4data download
         # local models, and MedCAT needs a running MedCATservice, so none are

--- a/src/bio_annotation/terminal_ui.py
+++ b/src/bio_annotation/terminal_ui.py
@@ -39,6 +39,15 @@ from bio_annotation.terminal_text_input import (
     write_generated_text_table,
     write_generated_text_table_from_raw_text_file,
 )
+from bio_annotation.terminal_theme import (
+    banner_lines,
+    choice_lines,
+    emit,
+    help_lines,
+    run_plan_lines,
+    run_summary_lines,
+    warning_lines,
+)
 
 InputFn = Callable[[str], str]
 OutputFn = Callable[[str], None]
@@ -78,20 +87,34 @@ def run_terminal_annotation_ui(
     output_fn: OutputFn = print,
     pipeline_run_fn: PipelineRunFn = run_pipeline_from_config,
 ) -> dict[str, Any]:
-    output_fn("TotalAnnotator interactive annotation")
-    output_fn("Choose an input source, annotators, and entity types. Output files will be saved in a stable directory.")
+    emit(output_fn, banner_lines())
+    emit(output_fn, help_lines())
     paths = create_run_paths(runs_dir)
     answers = collect_terminal_ui_answers(input_fn=input_fn, output_fn=output_fn)
+    emit(
+        output_fn,
+        run_plan_lines(
+            input_mode=_input_mode_label(answers.input_mode),
+            annotators=[_annotator_label(a) for a in answers.annotators],
+            entity_types=[_entity_type_label(e) for e in answers.entity_types],
+        ),
+    )
     prepare_input_files(answers, paths)
     write_terminal_ui_config(answers, paths.config_path, paths)
     load_pipeline_config(paths.config_path)
     if "aioner" in answers.annotators:
         _, aioner_model = aioner_config_paths()
         if not Path(aioner_model).exists():
-            output_fn(
-                f"Warning: AIONER model not found at {aioner_model}. "
-                "Run tools/aioner/setup.sh first, or set AIONER_REPO / AIONER_MODEL; "
-                "otherwise the AIONER step will be skipped this run."
+            emit(
+                output_fn,
+                warning_lines(
+                    "AIONER model not found",
+                    [
+                        f"Expected model path: {aioner_model}",
+                        "Run tools/aioner/setup.sh first, or set AIONER_REPO / AIONER_MODEL.",
+                        "Otherwise the AIONER step will be skipped this run.",
+                    ],
+                ),
             )
     if "medcat" in answers.annotators:
         medcat_endpoint = medcat_config_endpoint()
@@ -115,16 +138,17 @@ def run_terminal_annotation_ui(
     # only resolve its path to display it.
     report_path = pipeline_results_path.with_suffix(".html")
     output_fn("")
-    output_fn("Run complete")
-    output_fn(f"Documents: {payload.get('document_count', 0)}")
-    output_fn(f"Annotations: {payload.get('annotation_summary', {}).get('annotation_count', 0)}")
-    output_fn(f"Results: {paths.results_path}")
-    for label, path in terminal_ui_tsv_paths(paths).items():
-        output_fn(f"{label}: {path}")
-    output_fn(f"Config: {paths.config_path}")
-    output_fn(f"Manifest: {paths.manifest_path}")
-    output_fn(f"HTML report: {report_path}")
-    output_fn(f"Open {report_path.as_uri()} in your browser to view the annotated results.")
+    emit(
+        output_fn,
+        run_summary_lines(
+            document_count=payload.get("document_count", 0),
+            annotation_count=payload.get("annotation_summary", {}).get("annotation_count", 0),
+            results_path=paths.results_path,
+            tsv_paths=terminal_ui_tsv_paths(paths),
+            config_path=paths.config_path,
+            manifest_path=paths.manifest_path,
+        ),
+    )
     return payload
 
 
@@ -148,7 +172,16 @@ def collect_terminal_ui_answers(*, input_fn: InputFn, output_fn: OutputFn) -> Te
     elif mode == "pmid_file":
         pmid_file = _prompt_existing_pmid_file(input_fn=input_fn, output_fn=output_fn)
     else:
-        text_source = _prompt_choice(input_fn=input_fn, output_fn=output_fn, title="How do you want to provide plain text?", choices=(("table_file", "CSV/TSV table file with document_id, title, abstract columns"), ("text_file", "Raw text file with one text per line"), ("manual_text", "Enter text in the terminal")))
+        text_source = _prompt_choice(
+            input_fn=input_fn,
+            output_fn=output_fn,
+            title="How do you want to provide plain text?",
+            choices=(
+                ("table_file", "CSV/TSV table file with document_id, title, abstract columns"),
+                ("text_file", "Raw text file with one text per line"),
+                ("manual_text", "Enter text in the terminal"),
+            ),
+        )
         if text_source in {"table_file", "text_file"}:
             text_file = prompt_existing_file(input_fn=input_fn, output_fn=output_fn)
             if text_source == "table_file" and not is_text_table_file(text_file):
@@ -171,14 +204,31 @@ def collect_terminal_ui_answers(*, input_fn: InputFn, output_fn: OutputFn) -> Te
         validate_values=_validate_selected_annotators,
     )
     entity_types = _prompt_entity_types(input_fn=input_fn, output_fn=output_fn, annotators=annotators)
-    return TerminalUIAnswers(mode, pmids, pmid_file, annotators, entity_types, plain_text_file=text_file, plain_text_source=text_source, plain_text_content=text_content)
+    return TerminalUIAnswers(
+        mode,
+        pmids,
+        pmid_file,
+        annotators,
+        entity_types,
+        plain_text_file=text_file,
+        plain_text_source=text_source,
+        plain_text_content=text_content,
+    )
 
 
 def create_run_paths(runs_dir: Path, *, now: datetime | None = None) -> RunPaths:
     del now
     run_dir = runs_dir.expanduser().resolve()
     run_dir.mkdir(parents=True, exist_ok=True)
-    return RunPaths("annotation", run_dir, run_dir / "config.toml", run_dir / "results.json", run_dir / "run_manifest.json", run_dir / "pmids.txt", run_dir / "plain_text.tsv")
+    return RunPaths(
+        "annotation",
+        run_dir,
+        run_dir / "config.toml",
+        run_dir / "results.json",
+        run_dir / "run_manifest.json",
+        run_dir / "pmids.txt",
+        run_dir / "plain_text.tsv",
+    )
 
 
 def prepare_input_files(answers: TerminalUIAnswers, paths: RunPaths) -> None:
@@ -197,17 +247,11 @@ def write_terminal_ui_config(answers: TerminalUIAnswers, config_path: Path, path
     config_path.write_text(build_terminal_ui_config_text(answers, paths), encoding="utf-8")
 
 
-# AIONER head produced by tools/aioner/setup.sh, relative to the AIONER repo.
 AIONER_DEFAULT_MODEL_RELPATH = "pretrained_models/AIONER/PubmedBERT-CRF-AIONER.h5"
 
 
 def aioner_config_paths() -> tuple[str, str]:
-    """Resolve AIONER repo/model paths for the generated config.
-
-    AIONER has no universal default (unlike the public-API annotators), so the TUI
-    points at the conventional locations created by tools/aioner/setup.sh, with the
-    AIONER_REPO / AIONER_MODEL environment variables taking precedence.
-    """
+    """Resolve AIONER repo/model paths for the generated config."""
 
     repo_root = Path(__file__).resolve().parents[2]
     repo = os.environ.get("AIONER_REPO") or str(repo_root / "AIONER")
@@ -243,15 +287,41 @@ def build_terminal_ui_config_text(answers: TerminalUIAnswers, paths: RunPaths) -
         lines += ['mode = "pmid_file"', f"pmid_file = {_toml_string(str(answers.pmid_file))}"]
     elif answers.input_mode == "plain_text":
         text_file = _plain_text_config_file(answers, paths)
-        lines += ['mode = "text_table"', f"text_file = {_toml_string(str(text_file))}", f"format = {_toml_string(text_table_format(text_file))}", 'document_id_column = "document_id"', 'title_column = "title"', 'abstract_column = "abstract"']
+        lines += [
+            'mode = "text_table"',
+            f"text_file = {_toml_string(str(text_file))}",
+            f"format = {_toml_string(text_table_format(text_file))}",
+            'document_id_column = "document_id"',
+            'title_column = "title"',
+            'abstract_column = "abstract"',
+        ]
     else:
         raise ValueError(f"Unsupported terminal UI input mode: {answers.input_mode}")
     lines += ["", "[enrichment]", "sources = []", "", "[annotators]", f"enabled = {_toml_string_list(answers.annotators)}"]
     if "bern2" in answers.annotators:
-        lines += ["", "[annotators.bern2]", 'runtime = "remote_api"', f'endpoint = {_toml_string(DEFAULT_BERN2_API_URL)}', "timeout = 30"]
+        lines += [
+            "",
+            "[annotators.bern2]",
+            'runtime = "remote_api"',
+            f"endpoint = {_toml_string(DEFAULT_BERN2_API_URL)}",
+            "timeout = 30",
+        ]
     if "pubtator3" in answers.annotators:
         pubtator3_mode = "text_only" if answers.input_mode == "plain_text" else "auto"
-        lines += ["", "[annotators.pubtator3]", 'runtime = "remote_api"', 'endpoint = "https://www.ncbi.nlm.nih.gov/research/pubtator3-api"', 'format = "biocjson"', "timeout = 60", f"mode = {_toml_string(pubtator3_mode)}", 'bioconcept = "All"', "poll_interval_seconds = 2.0", "poll_backoff = 1.5", "max_poll_interval_seconds = 15.0", "max_poll_attempts = 30"]
+        lines += [
+            "",
+            "[annotators.pubtator3]",
+            'runtime = "remote_api"',
+            'endpoint = "https://www.ncbi.nlm.nih.gov/research/pubtator3-api"',
+            'format = "biocjson"',
+            "timeout = 60",
+            f"mode = {_toml_string(pubtator3_mode)}",
+            'bioconcept = "All"',
+            "poll_interval_seconds = 2.0",
+            "poll_backoff = 1.5",
+            "max_poll_interval_seconds = 15.0",
+            "max_poll_attempts = 30",
+        ]
     if "aioner" in answers.annotators:
         aioner_repo, aioner_model = aioner_config_paths()
         lines += ["", "[annotators.aioner]", 'runtime = "local_subprocess"', f"repo = {_toml_string(aioner_repo)}", f"model = {_toml_string(aioner_model)}", f"entity = {_toml_string(DEFAULT_AIONER_ENTITY)}", f"project = {_toml_string(DEFAULT_AIONER_PROJECT)}"]
@@ -266,13 +336,33 @@ def build_terminal_ui_config_text(answers: TerminalUIAnswers, paths: RunPaths) -
 
 
 def build_run_manifest(answers: TerminalUIAnswers, paths: RunPaths, payload: dict[str, Any]) -> dict[str, Any]:
-    manifest = {"run_id": paths.run_id, "created_at": datetime.now(timezone.utc).isoformat(), "input_mode": answers.input_mode, "annotators": answers.annotators, "annotator_labels": [_annotator_label(a) for a in answers.annotators], "entity_types": answers.entity_types, "entity_type_labels": [_entity_type_label(e) for e in answers.entity_types], "config_path": str(paths.config_path), "results_path": str(paths.results_path), "tsv_paths": {key: str(path) for key, path in terminal_ui_tsv_paths(paths).items()}, "manifest_path": str(paths.manifest_path), "document_count": payload.get("document_count", 0), "annotation_count": payload.get("annotation_summary", {}).get("annotation_count", 0)}
+    manifest = {
+        "run_id": paths.run_id,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "input_mode": answers.input_mode,
+        "annotators": answers.annotators,
+        "annotator_labels": [_annotator_label(a) for a in answers.annotators],
+        "entity_types": answers.entity_types,
+        "entity_type_labels": [_entity_type_label(e) for e in answers.entity_types],
+        "config_path": str(paths.config_path),
+        "results_path": str(paths.results_path),
+        "tsv_paths": {key: str(path) for key, path in terminal_ui_tsv_paths(paths).items()},
+        "manifest_path": str(paths.manifest_path),
+        "document_count": payload.get("document_count", 0),
+        "annotation_count": payload.get("annotation_summary", {}).get("annotation_count", 0),
+    }
     if answers.input_mode == "pmids":
         manifest.update({"pmids": answers.pmids, "pmids_count": len(answers.pmids)})
     elif answers.input_mode == "pmid_file":
         manifest.update({"pmid_file": str(answers.pmid_file) if answers.pmid_file else None})
     elif answers.input_mode == "plain_text":
-        manifest.update({"plain_text_source": answers.plain_text_source, "plain_text_file": str(answers.plain_text_file) if answers.plain_text_file else None, "plain_text_path": str(_plain_text_config_file(answers, paths))})
+        manifest.update(
+            {
+                "plain_text_source": answers.plain_text_source,
+                "plain_text_file": str(answers.plain_text_file) if answers.plain_text_file else None,
+                "plain_text_path": str(_plain_text_config_file(answers, paths)),
+            }
+        )
         if not _uses_existing_text_table(answers):
             manifest["plain_text_document_id"] = GENERATED_TEXT_DOCUMENT_ID
     return manifest
@@ -304,7 +394,11 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
 def find_unsupported_entity_types(annotators: list[str], entity_types: list[str]) -> dict[str, list[str]]:
     if not entity_types:
         return {}
-    return {a: missing for a in annotators if (missing := [e for e in entity_types if e not in ANNOTATOR_ENTITY_TYPES.get(a, set())])}
+    return {
+        a: missing
+        for a in annotators
+        if (missing := [e for e in entity_types if e not in ANNOTATOR_ENTITY_TYPES.get(a, set())])
+    }
 
 
 def _entity_type_choices_for(annotators: list[str]) -> tuple[tuple[str, str], ...]:
@@ -326,19 +420,18 @@ def _prompt_entity_types(*, input_fn: InputFn, output_fn: OutputFn, annotators: 
         unsupported = find_unsupported_entity_types(annotators, entity_types)
         if not unsupported:
             return entity_types
-        output_fn("")
-        output_fn("Entity type compatibility warning:")
-        for annotator, missing in unsupported.items():
-            output_fn(f"  {_annotator_label(annotator)} does not produce: {', '.join(_entity_type_label(e) for e in missing)}")
+        messages = [
+            f"{_annotator_label(annotator)} does not produce: {', '.join(_entity_type_label(e) for e in missing)}"
+            for annotator, missing in unsupported.items()
+        ]
+        emit(output_fn, warning_lines("Entity type compatibility warning", messages))
         if _prompt_yes_no(input_fn=input_fn, prompt="Continue with this selection? [y/N]: "):
             return entity_types
 
 
 def _prompt_choice(*, input_fn: InputFn, output_fn: OutputFn, title: str, choices: tuple[tuple[str, str], ...]) -> str:
     output_fn("")
-    output_fn(title)
-    for index, (_, label) in enumerate(choices, start=1):
-        output_fn(f"  {index}. {label}")
+    emit(output_fn, choice_lines(title, choices))
     while True:
         raw = input_fn("Choose one: ").strip()
         if raw.isdigit() and 1 <= int(raw) <= len(choices):
@@ -346,12 +439,20 @@ def _prompt_choice(*, input_fn: InputFn, output_fn: OutputFn, title: str, choice
         output_fn(f"Please choose one of: {', '.join(str(i) for i in range(1, len(choices) + 1))}")
 
 
-def _prompt_multi_choice(*, input_fn: InputFn, output_fn: OutputFn, title: str, choices: tuple[tuple[str, str], ...], default_values: list[str], allow_empty: bool = False, validate_values: Callable[[list[str]], None] | None = None) -> list[str]:
+def _prompt_multi_choice(
+    *,
+    input_fn: InputFn,
+    output_fn: OutputFn,
+    title: str,
+    choices: tuple[tuple[str, str], ...],
+    default_values: list[str],
+    allow_empty: bool = False,
+    validate_values: Callable[[list[str]], None] | None = None,
+) -> list[str]:
     output_fn("")
-    output_fn(title)
-    for index, (_, label) in enumerate(choices, start=1):
-        output_fn(f"  {index}. {label}")
-    default_hint = f" [default: {', '.join(str(i) for i, (v, _) in enumerate(choices, start=1) if v in default_values)}]" if default_values else ""
+    default_indexes = [i for i, (v, _) in enumerate(choices, start=1) if v in default_values]
+    emit(output_fn, choice_lines(title, choices, default_indexes=default_indexes))
+    default_hint = f" [default: {', '.join(str(i) for i in default_indexes)}]" if default_indexes else ""
     while True:
         raw = input_fn(f"Choose comma-separated numbers{default_hint}: ").strip()
         if not raw and default_values:
@@ -441,6 +542,14 @@ def _prompt_required(input_fn: InputFn, prompt: str) -> str:
 
 def _prompt_yes_no(*, input_fn: InputFn, prompt: str) -> bool:
     return input_fn(prompt).strip().lower() in {"y", "yes"}
+
+
+def _input_mode_label(input_mode: str) -> str:
+    return {
+        "pmids": "PubMed articles by PMID",
+        "pmid_file": "PubMed articles from a PMID file",
+        "plain_text": "Plain text",
+    }.get(input_mode, input_mode)
 
 
 def _annotator_label(annotator: str) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -1073,6 +1073,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1187,6 +1199,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/67/b2/ef8d6bb59b0edb6c16c968b70f548aa13b54348972def5aa6ac85df67145/matplotlib-3.10.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4e42042d54db34fda4e95a7bd3e5789c2a995d2dad3eb8850232ee534092fbbf", size = 9680884, upload-time = "2026-04-24T00:13:48.066Z" },
     { url = "https://files.pythonhosted.org/packages/61/1c/d21bfeb9931881ebe96bcfcff27c7ae4b160ae0ec291a714c42641a56d75/matplotlib-3.10.9-cp314-cp314t-win_amd64.whl", hash = "sha256:c27df8b3848f32a83d1767566595e43cfaa4460380974da06f4279a7ec143c39", size = 8432333, upload-time = "2026-04-24T00:13:51.008Z" },
     { url = "https://files.pythonhosted.org/packages/78/23/92493c3e6e1b635ccfff146f7b99e674808787915420373ac399283764c2/matplotlib-3.10.9-cp314-cp314t-win_arm64.whl", hash = "sha256:a49f1eadc84ca85fd72fa4e89e70e61bf86452df6f971af04b12c60761a0772c", size = 8324785, upload-time = "2026-04-24T00:13:53.633Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -2102,6 +2123,19 @@ socks = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "s3transfer"
 version = "0.16.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2456,6 +2490,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },
+    { name = "rich" },
 ]
 
 [package.optional-dependencies]
@@ -2495,6 +2530,7 @@ requires-dist = [
     { name = "flair", marker = "extra == 'flair'", specifier = "==0.15.1" },
     { name = "matplotlib", specifier = ">=3.8" },
     { name = "pandas", marker = "extra == 'benchmarks'", specifier = ">=2.0" },
+    { name = "rich", specifier = ">=13.7" },
     { name = "tabulate", marker = "extra == 'benchmarks'", specifier = ">=0.9" },
     { name = "torch", marker = "extra == 'apollo'", specifier = ">=2.0" },
     { name = "torch", marker = "extra == 'd4data'", specifier = ">=2.0" },


### PR DESCRIPTION
## Summary

  - Add Rich-based styling for the interactive terminal annotation UI.
  - Polish the annotation flow screens with rounded panels, colored tables, clearer default annotator labels, and updated banner wording.

  ## Testing

  - `uv run pytest -q`

  Result: `132 passed, 1 skipped, 2 warnings`


PS. Any recommendations for better display through other packages or functions they will be well received!