### PR TITLE
Fix bern2 entity types

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ TotalAnnotator supports:
 - PubMed articles from inline PMIDs or a PMID file
 - local plain text from a CSV/TSV table, raw text file, or manual terminal input
 - live annotation with PubTator3, BERN2, and Flair/HunFlair
-- entity-type filtering for genes/proteins, diseases, chemicals/drugs, species, variants, and cell lines
+- entity-type filtering for genes/proteins, diseases, chemicals/drugs, species, variants, cell lines, cell types, DNA, and RNA
 - canonical JSON output plus TSV files for spreadsheet-friendly review
 - reproducible TOML configs for every terminal UI run
 - direct config-based pipeline runs for scripted workflows
@@ -143,6 +143,18 @@ timeout = 30
 
 Local BERN2 endpoints such as `localhost` or `127.0.0.1` are also supported.
 
+BERN2 supports:
+
+- gene/protein
+- disease
+- chemical/drug
+- species
+- variant/mutation
+- cell line
+- cell type
+- DNA
+- RNA
+
 ### Flair / HunFlair
 
 Flair/HunFlair runs through the configured local Flair model.
@@ -169,6 +181,9 @@ TotalAnnotator normalizes annotator labels into canonical entity types:
 | `species` | Species |
 | `variant` | Variant / mutation |
 | `cell_line` | Cell line |
+| `cell_type` | Cell type |
+| `dna` | DNA |
+| `rna` | RNA |
 
 If no entity types are selected, the pipeline keeps all returned entity types.
 

--- a/docs/workflow-spec.md
+++ b/docs/workflow-spec.md
@@ -134,7 +134,7 @@ sources = []
 enabled = ["bern2", "pubtator", "flair"]
 
 [filters]
-entity_types = ["gene", "drug", "mutation"]
+entity_types = ["gene", "drug", "variant"]
 
 [output]
 path = "outputs/current_run.json"
@@ -179,9 +179,12 @@ Example project vocabulary:
 - `protein`
 - `drug`
 - `disease`
-- `mutation`
+- `variant`
 - `species`
 - `cell_line`
+- `cell_type`
+- `dna`
+- `rna`
 
 Important: this mapping should be internal adapter logic, not user-facing
 configuration. A user should not need to write mapping tables to run a new
@@ -202,7 +205,7 @@ Example:
 
 ```toml
 [filters]
-entity_types = ["gene", "drug", "mutation"]
+entity_types = ["gene", "drug", "variant"]
 ```
 
 Before running the workflow, TotalAnnotator should validate whether the selected
@@ -213,7 +216,7 @@ The system should report compatibility in three levels:
 - `Info`
   Example: `pubtator label "Chemical" will be reported as project type "drug"`
 - `Warning`
-  Example: `flair does not provide "mutation"; this type will only be collected from bern2 and pubtator`
+  Example: `flair does not provide "variant"; this type will only be collected from bern2 and pubtator`
 - `Error`
   Example: `selected annotators do not provide the requested entity type "cell_line"`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ dev = [
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+"bio_annotation.report" = ["template.html"]
+
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 markers = [

--- a/src/bio_annotation/entity_types.py
+++ b/src/bio_annotation/entity_types.py
@@ -45,6 +45,10 @@ ANNOTATOR_ENTITY_TYPE_SPECS: tuple[AnnotatorEntityTypeSpec, ...] = (
     AnnotatorEntityTypeSpec("bern2", "BERN2", "Drug", "drug", ("DrugBank",)),
     AnnotatorEntityTypeSpec("bern2", "BERN2", "Species", "species", ("NCBI Taxonomy",)),
     AnnotatorEntityTypeSpec("bern2", "BERN2", "Mutation / variant", "variant", ("dbSNP",)),
+    AnnotatorEntityTypeSpec("bern2", "BERN2", "Cell line", "cell_line", ("Cellosaurus",)),
+    AnnotatorEntityTypeSpec("bern2", "BERN2", "Cell type", "cell_type", ("Cell Ontology",)),
+    AnnotatorEntityTypeSpec("bern2", "BERN2", "DNA", "dna", ()),
+    AnnotatorEntityTypeSpec("bern2", "BERN2", "RNA", "rna", ()),
     AnnotatorEntityTypeSpec("flair", "Flair / HunFlair", "Gene / protein", "gene", ()),
     AnnotatorEntityTypeSpec("flair", "Flair / HunFlair", "Disease", "disease", ()),
     AnnotatorEntityTypeSpec("flair", "Flair / HunFlair", "Chemical / drug", "drug", ()),
@@ -66,16 +70,45 @@ ENTITY_TYPE_DISPLAY_NAMES: dict[str, str] = {
     "species": "Species",
     "variant": "Variant / mutation",
     "cell_line": "Cell line",
+    "cell_type": "Cell type",
+    "dna": "DNA",
+    "rna": "RNA",
 }
 ENTITY_TYPE_CHOICES: tuple[tuple[str, str], ...] = tuple(
     (entity_type, ENTITY_TYPE_DISPLAY_NAMES[entity_type])
-    for entity_type in ("gene", "disease", "drug", "species", "variant", "cell_line")
+    for entity_type in (
+        "gene",
+        "disease",
+        "drug",
+        "species",
+        "variant",
+        "cell_line",
+        "cell_type",
+        "dna",
+        "rna",
+    )
 )
 ENTITY_TYPE_ALIASES: dict[str, str] = {
     re.sub(r"[^a-z0-9]+", "_", spec.source_entity_type.strip().lower()).strip("_"): spec.canonical_entity_type
     for spec in ANNOTATOR_ENTITY_TYPE_SPECS
 }
 ENTITY_TYPE_ALIASES.update({canonical: canonical for canonical in ENTITY_TYPE_DISPLAY_NAMES})
+ENTITY_TYPE_ALIASES.update(
+    {
+        "cellline": "cell_line",
+        "cell_line": "cell_line",
+        "celltype": "cell_type",
+        "cell_type": "cell_type",
+        "chemical": "drug",
+        "drug": "drug",
+        "gene": "gene",
+        "protein": "gene",
+        "mutation": "variant",
+        "variant": "variant",
+        "dna": "dna",
+        "rna": "rna",
+    }
+)
 
 
 ANNOTATOR_CAPABILITIES: dict[str, AnnotatorCapability] = {

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -16,6 +16,7 @@ from bio_annotation.annotators.flair import annotate_with_flair
 from bio_annotation.annotators.pubtator3 import annotate_with_pubtator3
 from bio_annotation.entity_types import normalize_entity_type
 from bio_annotation.pipeline_config import PipelineConfig, load_pipeline_config
+from bio_annotation.report import write_html_report
 from bio_annotation.preprocessing.document_loader import (
     load_documents_from_config,
     load_documents_from_pmid_file,
@@ -193,6 +194,7 @@ def write_pipeline_output(payload: dict[str, Any], output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     write_pipeline_tsv_outputs(payload, output_path)
+    write_html_report(payload, output_path.with_suffix(".html"))
 
 
 def timestamped_output_path(output_path: Path, *, now: datetime | None = None) -> Path:

--- a/src/bio_annotation/report/__init__.py
+++ b/src/bio_annotation/report/__init__.py
@@ -1,0 +1,3 @@
+from bio_annotation.report.html_report import write_html_report
+
+__all__ = ["write_html_report"]

--- a/src/bio_annotation/report/html_report.py
+++ b/src/bio_annotation/report/html_report.py
@@ -100,6 +100,38 @@ def _database_link(canonical_id: str | None, entity_type: str | None) -> str | N
     return None
 
 
+_ID_PREFIX_CANONICAL: dict[str, str] = {
+    "mesh": "MESH",
+    "ncbigene": "NCBIGene", "ncbi_gene": "NCBIGene", "ncbi-gene": "NCBIGene",
+    "ncbitaxon": "NCBITaxon", "ncbitaxonomy": "NCBITaxon", "ncbi_taxonomy": "NCBITaxon",
+    "taxonomy": "NCBITaxon", "taxon": "NCBITaxon",
+    "dbsnp": "dbSNP", "chebi": "CHEBI", "drugbank": "DrugBank",
+    "cellosaurus": "CVCL", "cvcl": "CVCL", "omim": "OMIM", "mim": "OMIM",
+    "cl": "CL", "go": "GO", "doid": "DOID", "uberon": "UBERON", "bto": "BTO", "fma": "FMA", "pato": "PATO",
+}
+
+
+def _format_canonical_id(canonical_id: Any, entity_type: str | None = None) -> str:
+    """Render an id with one consistent prefix casing (mirror of the JS formatId).
+
+    Only the prefix casing changes; the id value is untouched, and a bare
+    gene/species number gains the prefix the prefixed annotators use.
+    """
+    if not canonical_id:
+        return ""
+    raw = str(canonical_id).strip()
+    if ":" not in raw:
+        if raw.isdigit():
+            if entity_type == "gene":
+                return f"NCBIGene:{raw}"
+            if entity_type == "species":
+                return f"NCBITaxon:{raw}"
+        return raw
+    prefix, rest = raw.split(":", 1)
+    canon = _ID_PREFIX_CANONICAL.get(prefix.lower())
+    return f"{canon}:{rest}" if canon else raw
+
+
 def write_html_report(payload: dict[str, Any], output_path: Path) -> Path:
     """Generates a standalone HTML report next to the run's other outputs.
 
@@ -497,7 +529,7 @@ def _render_hits_cell(hits: list[dict[str, Any]]) -> str:
         line = f'<div class="entity-type">{escape(str(label))}</div>'
         if canonical_id:
             link = _database_link(canonical_id, entity_type)
-            code = f'<code>{escape(str(canonical_id))}</code>'
+            code = f'<code>{escape(_format_canonical_id(canonical_id, entity_type))}</code>'
             if link:
                 code = f'<a href="{escape(link, quote=True)}" target="_blank" rel="noopener">{code}</a>'
             line += f"<div>{code}</div>"

--- a/src/bio_annotation/report/html_report.py
+++ b/src/bio_annotation/report/html_report.py
@@ -1,0 +1,664 @@
+from __future__ import annotations
+
+import json
+import math
+from collections import defaultdict
+from html import escape
+from pathlib import Path
+from typing import Any
+
+_TEMPLATE_PATH = Path(__file__).resolve().parent / "template.html"
+
+# When annotators overlap on the same span, this is the order they appear in.
+_SOURCE_PRIORITY: dict[str, int] = {"pubtator3": 0, "bern2": 1, "flair": 2}
+
+_ANNOTATOR_LABELS: dict[str, str] = {
+    "pubtator3": "PubTator3",
+    "bern2": "BERN2",
+    "flair": "Flair / HunFlair",
+}
+
+_ENTITY_TYPE_LABELS: dict[str, str] = {
+    "gene": "Gene / protein",
+    "disease": "Disease",
+    "drug": "Chemical / drug",
+    "species": "Species",
+    "variant": "Variant / mutation",
+    "cell_line": "Cell line",
+    # BERN2-only categories, kept as their own buckets.
+    "dna": "DNA",
+    "rna": "RNA ",
+    "cell_type": "Cell type",
+}
+
+
+# "no concept found"
+_NULL_CANONICAL_IDS: frozenset[str] = frozenset({"cui-less", "-", ""})
+
+
+def _is_real_canonical_id(value: Any) -> bool:
+    if value is None:
+        return False
+    text = str(value).strip().lower()
+    return text not in _NULL_CANONICAL_IDS
+
+
+def _json_safe(value: Any) -> Any:
+    """Replace NaN/Infinity floats with None so the result is valid JSON.
+
+    Python's json emits a bare NaN (e.g. from a BERN2 confidence), which the
+    browser's JSON.parse rejects, so the popup would silently fail to open.
+    """
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if isinstance(value, dict):
+        return {key: _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+# Server-side mirror of the JS `databaseLink`.
+def _database_link(canonical_id: str | None, entity_type: str | None) -> str | None:
+    if not canonical_id:
+        return None
+    raw = str(canonical_id).strip()
+    if not raw:
+        return None
+    lowered = raw.lower()
+    if lowered.startswith("mesh:"):
+        return f"https://meshb.nlm.nih.gov/record/ui?ui={raw.split(':', 1)[1]}"
+    if lowered.startswith("ncbigene:") or lowered.startswith("ncbi_gene:") or lowered.startswith("ncbi-gene:"):
+        return f"https://www.ncbi.nlm.nih.gov/gene/{raw.split(':', 1)[1]}"
+    if (
+        lowered.startswith("ncbitaxon:") or lowered.startswith("ncbitaxonomy:")
+        or lowered.startswith("ncbi_taxonomy:") or lowered.startswith("ncbi-taxonomy:")
+        or lowered.startswith("taxonomy:") or lowered.startswith("taxon:")
+    ):
+        return f"https://www.ncbi.nlm.nih.gov/taxonomy/{raw.split(':', 1)[1]}"
+    if lowered.startswith("dbsnp:") or lowered.startswith("rs:"):
+        return f"https://www.ncbi.nlm.nih.gov/snp/{raw.split(':', 1)[1]}"
+    if lowered.startswith("chebi:"):
+        return f"https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:{raw.split(':', 1)[1]}"
+    if lowered.startswith("drugbank:"):
+        return f"https://go.drugbank.com/drugs/{raw.split(':', 1)[1]}"
+    if lowered.startswith("cvcl:") or lowered.startswith("cellosaurus:"):
+        suffix = raw.split(":", 1)[1]
+        ref = suffix if suffix.startswith("CVCL_") else f"CVCL_{suffix}"
+        return f"https://www.cellosaurus.org/{ref}"
+    if lowered.startswith("omim:") or lowered.startswith("mim:"):
+        return f"https://www.omim.org/entry/{raw.split(':', 1)[1]}"
+    if entity_type == "gene" and raw.isdigit():
+        return f"https://www.ncbi.nlm.nih.gov/gene/{raw}"
+    if entity_type == "species" and raw.isdigit():
+        return f"https://www.ncbi.nlm.nih.gov/taxonomy/{raw}"
+    # OBO ontologies (e.g. BERN2 cell_type -> Cell Ontology "CL:..."):
+    # resolve via the PURL redirect.
+    for obo_prefix in ("cl", "go", "doid", "uberon", "bto", "fma", "pato"):
+        if lowered.startswith(obo_prefix + ":"):
+            return f"https://purl.obolibrary.org/obo/{obo_prefix.upper()}_{raw.split(':', 1)[1]}"
+    return None
+
+
+def write_html_report(payload: dict[str, Any], output_path: Path) -> Path:
+    """Generates a standalone HTML report next to the run's other outputs.
+
+    Returns the absolute path of the file that was written.
+    """
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    content_html = _render_body(payload)
+    template = _TEMPLATE_PATH.read_text(encoding="utf-8")
+    html = template.replace("<!--CONTENT-->", content_html)
+    output_path.write_text(html, encoding="utf-8")
+    return output_path.resolve()
+
+
+def _render_body(payload: dict[str, Any]) -> str:
+    summary = payload.get("annotation_summary") or {}
+    documents = list(payload.get("documents") or [])
+    annotations = list(payload.get("annotations") or [])
+
+    annotators_used = sorted(
+        {a.get("source") for a in annotations if a.get("source")}
+    )
+    annotators_text = ", ".join(
+        _ANNOTATOR_LABELS.get(name, name) for name in annotators_used
+    ) or "none"
+    total_annotations = summary.get("annotation_count", len(annotations))
+    document_count = payload.get("document_count", len(documents))
+
+    parts: list[str] = []
+    parts.append('<section class="summary">')
+    parts.append('<div class="summary-headline">')
+    parts.append(
+        f'<p class="lede"><span class="big-number">{total_annotations}</span> '
+        f'annotation{"s" if total_annotations != 1 else ""} across '
+        f'<span class="big-number">{document_count}</span> '
+        f'document{"s" if document_count != 1 else ""}</p>'
+    )
+    parts.append(f'<p class="meta">Annotators: {escape(annotators_text)}</p>')
+    parts.append("</div>")
+    if annotations:
+        parts.append(_render_stats_panel(
+            _compute_stats(annotations),
+            heading="Bioconcepts in this run",
+            css_class="stats-run",
+        ))
+    parts.append("</section>")
+    parts.append(_render_legend(annotations))
+
+    if annotations:
+        parts.append(_render_type_histogram(annotations))
+    if len(documents) > 1:
+        parts.append(_render_documents_overview(documents, annotations))
+
+    for document in documents:
+        parts.append(_render_document(document, annotations))
+
+    if not documents:
+        parts.append('<p class="hint">No documents in this run.</p>')
+
+    return "\n".join(parts)
+
+
+def _compute_stats(annotations: list[dict[str, Any]]) -> dict[str, list[tuple[str, int]]]:
+    """Group annotations by entity type, then by case-insensitive span text.
+    Multiple annotators tagging the same span at the same
+    offset count as one mention, matching PubTator3's "Bioconcepts and
+    mentions" panel.
+    """
+    positions: dict[str, dict[str, set[tuple[Any, Any]]]] = {}
+    canonical: dict[str, dict[str, str]] = {}
+    for annotation in annotations:
+        span_text = (annotation.get("span_text") or "").strip()
+        if not span_text:
+            continue
+        entity_type = (annotation.get("entity_type") or "unknown").lower()
+        key = span_text.casefold()
+        positions.setdefault(entity_type, {}).setdefault(key, set()).add(
+            (annotation.get("start"), annotation.get("end"))
+        )
+        canonical.setdefault(entity_type, {}).setdefault(key, span_text)
+
+    result: dict[str, list[tuple[str, int]]] = {}
+    for entity_type, by_key in positions.items():
+        rows = [
+            (canonical[entity_type][key], len(positions_set))
+            for key, positions_set in by_key.items()
+        ]
+        rows.sort(key=lambda item: (-item[1], item[0].casefold()))
+        result[entity_type] = rows
+    return result
+
+
+def _render_stats_panel(
+    stats: dict[str, list[tuple[str, int]]],
+    *,
+    heading: str,
+    css_class: str,
+    limit_per_type: int = 15,
+) -> str:
+    if not stats:
+        return ""
+    type_order = [
+        key for key in ("disease", "drug", "gene", "species", "variant", "cell_line")
+        if key in stats
+    ]
+    type_order += [key for key in stats if key not in type_order]
+
+    parts: list[str] = [f'<aside class="stats-panel {css_class}">']
+    parts.append(f'<h4>{escape(heading)}</h4>')
+    for entity_type in type_order:
+        rows = stats[entity_type]
+        if not rows:
+            continue
+        label = _ENTITY_TYPE_LABELS.get(entity_type, entity_type)
+        total = sum(count for _, count in rows)
+        parts.append(
+            f'<details class="stats-group stats-group-{escape(entity_type)}">'
+            f'<summary><span class="stats-type">{escape(label)}</span>'
+            f'<span class="stats-type-total">{total}</span></summary>'
+        )
+        parts.append('<ul class="stats-list">')
+        max_count = rows[0][1] if rows else 1
+        for keyword, count in rows[:limit_per_type]:
+            width_pct = max(6, int(round(100 * count / max_count))) if max_count else 0
+            parts.append(
+                f'<li>'
+                f'<span class="stats-keyword">{escape(keyword)}</span>'
+                f'<span class="stats-bar-track"><span class="stats-bar-fill" style="width:{width_pct}%"></span></span>'
+                f'<span class="stats-count">{count}</span>'
+                f'</li>'
+            )
+        if len(rows) > limit_per_type:
+            remaining = len(rows) - limit_per_type
+            parts.append(f'<li class="stats-more">+{remaining} more</li>')
+        parts.append("</ul></details>")
+    parts.append("</aside>")
+    return "\n".join(parts)
+
+
+def _render_type_histogram(annotations: list[dict[str, Any]]) -> str:
+    counts: dict[str, int] = {}
+    for annotation in annotations:
+        entity_type = (annotation.get("entity_type") or "unknown").lower()
+        counts[entity_type] = counts.get(entity_type, 0) + 1
+    if not counts:
+        return ""
+    ordered = [
+        key for key in ("disease", "drug", "gene", "species", "variant", "cell_line")
+        if key in counts
+    ]
+    ordered += sorted(key for key in counts if key not in ordered)
+    max_count = max(counts.values())
+
+    parts = ['<section class="chart-card">',
+             '<h4>Entity type distribution</h4>',
+             '<ul class="type-histogram">']
+    for entity_type in ordered:
+        count = counts[entity_type]
+        label = _ENTITY_TYPE_LABELS.get(entity_type, entity_type.replace("_", " ").title())
+        width = max(4, int(round(100 * count / max_count)))
+        parts.append(
+            f'<li class="hist-row hist-row-{escape(entity_type)}">'
+            f'<span class="hist-label">{escape(label)}</span>'
+            f'<span class="hist-track"><span class="hist-fill" style="width:{width}%"></span></span>'
+            f'<span class="hist-count">{count}</span>'
+            f'</li>'
+        )
+    parts.append('</ul></section>')
+    return "\n".join(parts)
+
+
+def _render_documents_overview(
+    documents: list[dict[str, Any]], annotations: list[dict[str, Any]]
+) -> str:
+    by_doc: dict[Any, dict[str, int]] = {}
+    for annotation in annotations:
+        document_id = annotation.get("document_id")
+        entity_type = (annotation.get("entity_type") or "unknown").lower()
+        by_doc.setdefault(document_id, {})[entity_type] = (
+            by_doc.setdefault(document_id, {}).get(entity_type, 0) + 1
+        )
+
+    doc_totals = [
+        (doc, sum(by_doc.get(doc.get("document_id"), {}).values()))
+        for doc in documents
+    ]
+    max_total = max((total for _, total in doc_totals), default=0)
+    if max_total == 0:
+        return ""
+
+    type_order = ("disease", "drug", "gene", "species", "variant", "cell_line")
+
+    parts = ['<section class="chart-card">',
+             '<h4>Annotations per document</h4>',
+             '<ul class="doc-overview">']
+    for document, total in doc_totals:
+        doc_id = str(document.get("document_id") or "")
+        pmid = document.get("pmid")
+        title = (document.get("title") or doc_id or "Document")
+        truncated = title if len(title) <= 70 else title[:67] + "..."
+        link_text = f"PMID {pmid}" if pmid else doc_id or "Document"
+        anchor = _anchor_for(doc_id)
+        type_counts = by_doc.get(document.get("document_id"), {})
+        ordered_types = [t for t in type_order if t in type_counts]
+        ordered_types += [t for t in type_counts if t not in ordered_types]
+
+        segments: list[str] = []
+        running_total = sum(type_counts.values())
+        for entity_type in ordered_types:
+            seg_count = type_counts[entity_type]
+            seg_width = 100 * seg_count / running_total if running_total else 0
+            segments.append(
+                f'<span class="doc-seg doc-seg-{escape(entity_type)}" '
+                f'style="width:{seg_width:.2f}%" '
+                f'title="{escape(_ENTITY_TYPE_LABELS.get(entity_type, entity_type))}: {seg_count}"></span>'
+            )
+        bar_width = max(8, int(round(100 * total / max_total)))
+        parts.append(
+            f'<li class="doc-row">'
+            f'<a class="doc-link" href="#{escape(anchor, quote=True)}">{escape(link_text)}</a>'
+            f'<span class="doc-title">{escape(truncated)}</span>'
+            f'<span class="doc-track"><span class="doc-bar" style="width:{bar_width}%">{"".join(segments)}</span></span>'
+            f'<span class="doc-count">{total}</span>'
+            f'</li>'
+        )
+    parts.append('</ul></section>')
+    return "\n".join(parts)
+
+
+def _anchor_for(document_id: str) -> str:
+    return "doc-" + "".join(ch if ch.isalnum() else "-" for ch in document_id).strip("-").lower()
+
+
+def _render_legend(annotations: list[dict[str, Any]] | None = None) -> str:
+    """Render legend chips. If annotations are passed, only show the types
+    actually present in this run; otherwise show every known type."""
+    if annotations is not None:
+        present = {
+            (a.get("entity_type") or "unknown").lower()
+            for a in annotations
+        }
+        items = [
+            f'<span class="legend-chip legend-chip-{key}">{escape(label)}</span>'
+            for key, label in _ENTITY_TYPE_LABELS.items()
+            if key in present
+        ]
+    else:
+        items = [
+            f'<span class="legend-chip legend-chip-{key}">{escape(label)}</span>'
+            for key, label in _ENTITY_TYPE_LABELS.items()
+        ]
+    return '<div class="legend">' + "".join(items) + "</div>"
+
+
+def _render_document(document: dict[str, Any], all_annotations: list[dict[str, Any]]) -> str:
+    document_id = document.get("document_id")
+    document_annotations = [
+        annotation for annotation in all_annotations
+        if annotation.get("document_id") == document_id
+    ]
+    comparison_rows = group_annotations_by_span(document_annotations)
+    cross_lookup = {row["keyword"].casefold(): row["by_source"] for row in comparison_rows}
+
+    title_text = (document.get("title") or "").strip()
+    abstract_text = (document.get("abstract") or "").strip()
+    title_annotations, abstract_annotations = _split_annotations_by_region(
+        document_annotations, len(title_text)
+    )
+
+    title_html = (
+        render_highlighted_text(title_text, title_annotations, cross_lookup)
+        if title_text
+        else escape(str(document_id or "Document"))
+    )
+    pmid = document.get("pmid")
+    pmid_html = (
+        f' | PMID: <a href="https://pubmed.ncbi.nlm.nih.gov/{escape(str(pmid))}/" target="_blank" rel="noopener">{escape(str(pmid))}</a>'
+        if pmid else ""
+    )
+
+    anchor = _anchor_for(str(document_id or ""))
+    plain_title = escape(title_text) if title_text else escape(str(document_id or "Document"))
+    annotation_count = len(document_annotations)
+    count_label = f'{annotation_count} annotation{"s" if annotation_count != 1 else ""}'
+    parts: list[str] = [f'<details class="document" id="{escape(anchor, quote=True)}">']
+    parts.append(
+        f'<summary class="doc-summary">'
+        f'<span class="doc-summary-title">{plain_title}</span>'
+        f'<span class="doc-summary-count">{count_label}</span>'
+        f"</summary>"
+    )
+    parts.append('<div class="doc-body">')
+    parts.append(f"<h2>{title_html}</h2>")
+    parts.append(
+        f'<p class="meta">{pmid_html}'
+        f"{' | ' if pmid else ''}{count_label} on this document</p>"
+    )
+    parts.append('<div class="doc-grid">')
+    parts.append('<div class="doc-main">')
+    parts.append("<h3>Abstract</h3>")
+    parts.append('<p class="hint">Highlights show entities found by any annotator. Click a highlight for full details across annotators.</p>')
+    body_html = (
+        render_highlighted_text(abstract_text, abstract_annotations, cross_lookup)
+        if abstract_text
+        else '<span class="hint">No abstract available.</span>'
+    )
+    parts.append(f'<div class="annotated-text">{body_html}</div>')
+    parts.append("</div>")
+    parts.append(_render_stats_panel(
+        _compute_stats(document_annotations),
+        heading="Bioconcepts in this document",
+        css_class="stats-doc",
+    ))
+    parts.append("</div>")
+
+    parts.append(
+        f'<details class="comparison-section">'
+        f'<summary><h3>Comparison across annotators</h3>'
+        f'<span class="hint">{len(comparison_rows)} unique keyword'
+        f'{"s" if len(comparison_rows) != 1 else ""} found by at least one annotator</span></summary>'
+    )
+    parts.append('<div class="comparison-scroll">')
+    parts.append(_render_comparison_table(comparison_rows))
+    parts.append("</div></details>")
+    parts.append("</div>")
+    parts.append("</details>")
+    return "\n".join(parts)
+
+
+def _split_annotations_by_region(
+    annotations: list[dict[str, Any]], title_length: int
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Partition canonical-scheme annotations into title-region and abstract-region.
+
+    Canonical text is `title + "\\n" + abstract`. Annotations with offsets
+    fully inside [0, title_length) belong to the title. Annotations starting
+    at or past `title_length + 2` belong to the abstract; their offsets are
+    rebased so position 0 maps to the start of the abstract.
+    """
+    title_annotations: list[dict[str, Any]] = []
+    abstract_annotations: list[dict[str, Any]] = []
+    # Document.text is "title\n\nabstract" only when there is a title; a
+    # title-less doc (e.g. plain-text input) is just the abstract, no shift.
+    body_offset = title_length + 2 if title_length else 0
+    for annotation in annotations:
+        start = annotation.get("start")
+        end = annotation.get("end")
+        if start is None or end is None:
+            continue
+        if title_length and end <= title_length:
+            title_annotations.append(annotation)
+        elif start >= body_offset:
+            abstract_annotations.append(
+                {**annotation, "start": start - body_offset, "end": end - body_offset}
+            )
+    return title_annotations, abstract_annotations
+
+
+def _render_comparison_table(rows: list[dict[str, Any]]) -> str:
+    if not rows:
+        return '<p class="hint">No annotations to compare.</p>'
+
+    sources = ("pubtator3", "bern2", "flair")
+    head_cells = "".join(
+        f"<th>{escape(_ANNOTATOR_LABELS.get(source, source))}</th>" for source in sources
+    )
+    body_rows: list[str] = []
+    for row in rows:
+        cells = [f'<td><code>{escape(row["keyword"])}</code></td>']
+        for source in sources:
+            hits = row["by_source"].get(source) or []
+            cells.append(f"<td>{_render_hits_cell(hits)}</td>")
+        body_rows.append("<tr>" + "".join(cells) + "</tr>")
+
+    return (
+        '<table class="comparison"><thead><tr>'
+        f"<th>Keyword</th>{head_cells}"
+        "</tr></thead><tbody>"
+        + "".join(body_rows)
+        + "</tbody></table>"
+    )
+
+
+def _render_hits_cell(hits: list[dict[str, Any]]) -> str:
+    if not hits:
+        return '<span class="absent">·</span>'
+    lines: list[str] = []
+    for hit in hits:
+        entity_type = (hit.get("entity_type") or "").lower() or "unknown"
+        label = _ENTITY_TYPE_LABELS.get(entity_type, entity_type)
+        canonical_id = hit.get("canonical_id") if _is_real_canonical_id(hit.get("canonical_id")) else None
+        canonical_name = hit.get("canonical_name")
+        mentions = hit.get("mentions")
+        line = f'<div class="entity-type">{escape(str(label))}</div>'
+        if canonical_id:
+            link = _database_link(canonical_id, entity_type)
+            code = f'<code>{escape(str(canonical_id))}</code>'
+            if link:
+                code = f'<a href="{escape(link, quote=True)}" target="_blank" rel="noopener">{code}</a>'
+            line += f"<div>{code}</div>"
+        if canonical_name:
+            line += f"<div><small>{escape(str(canonical_name))}</small></div>"
+        if mentions and mentions > 1:
+            line += f'<div><small>{mentions} mentions</small></div>'
+        lines.append(line)
+    return "<br>".join(lines)
+
+
+def build_canonical_text(document: dict[str, Any]) -> str:
+    title = document.get("title") or ""
+    abstract = document.get("abstract") or ""
+    if title and abstract:
+        return f"{title}\n{abstract}"
+    return title or abstract
+
+
+def _source_priority(source: str | None) -> int:
+    return _SOURCE_PRIORITY.get(source or "", 99)
+
+
+def render_highlighted_text(
+    text: str,
+    annotations: list[dict[str, Any]],
+    cross_annotator_lookup: dict[str, dict[str, list[dict[str, Any]]]] | None = None,
+) -> str:
+    """Render the document text with non-overlapping <mark> spans.
+
+    """
+    if not annotations:
+        return escape(text).replace("\n", "<br>\n")
+
+    sorted_annotations = sorted(
+        annotations,
+        key=lambda a: (
+            a.get("start") or 0,
+            _source_priority(a.get("source")),
+            -((a.get("end") or 0) - (a.get("start") or 0)),
+        ),
+    )
+
+    chosen: list[dict[str, Any]] = []
+    last_end = -1
+    for annotation in sorted_annotations:
+        start = annotation.get("start")
+        end = annotation.get("end")
+        if start is None or end is None or end <= start:
+            continue
+        if start >= last_end:
+            chosen.append(annotation)
+            last_end = end
+
+    out: list[str] = []
+    position = 0
+    for annotation in chosen:
+        start = annotation["start"]
+        end = annotation["end"]
+        if start > position:
+            out.append(escape(text[position:start]).replace("\n", "<br>\n"))
+        rendered_span = escape(text[start:end])
+        entity_type = (annotation.get("entity_type") or "unknown").lower()
+        source = annotation.get("source") or "unknown"
+        raw_canonical_id = annotation.get("canonical_id")
+        canonical_id = raw_canonical_id if _is_real_canonical_id(raw_canonical_id) else ""
+        canonical_name = annotation.get("canonical_name") or ""
+        keyword_key = (annotation.get("span_text") or text[start:end]).strip().casefold()
+        cross_hit = cross_annotator_lookup.get(keyword_key) if cross_annotator_lookup else None
+
+        popup_payload: dict[str, Any] = {
+            "keyword": text[start:end],
+            "entity_type": entity_type,
+            "canonical_id": canonical_id or None,
+            "canonical_name": canonical_name or None,
+            "primary_source": source,
+            "by_source": cross_hit or {source: [_hit_record(annotation)]},
+        }
+        data_attribute = escape(json.dumps(_json_safe(popup_payload), default=str), quote=True)
+
+        css_type = entity_type
+        out.append(
+            f'<mark class="entity entity-{escape(css_type)}" '
+            f'data-entity="{data_attribute}" tabindex="0" role="button">{rendered_span}</mark>'
+        )
+        position = end
+    if position < len(text):
+        out.append(escape(text[position:]).replace("\n", "<br>\n"))
+    return "".join(out)
+
+
+def group_annotations_by_span(annotations: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group annotations across annotators by case-insensitive span text.
+
+    Each row carries the keyword and a dict of annotator -> list of hits.
+    Within each source, hits with identical (entity_type, canonical_id,
+    canonical_name) collapse to one row with a `mentions` count.
+    """
+    groups: dict[str, dict[str, Any]] = {}
+    for annotation in annotations:
+        span_text = (annotation.get("span_text") or "").strip()
+        if not span_text:
+            continue
+        key = span_text.casefold()
+        bucket = groups.setdefault(
+            key,
+            {
+                "keyword": span_text,
+                "by_source": defaultdict(list),
+                "first_offset": annotation.get("start") or 0,
+            },
+        )
+        source = annotation.get("source") or "unknown"
+        bucket["by_source"][source].append(_hit_record(annotation))
+        if (annotation.get("start") or 0) < bucket["first_offset"]:
+            bucket["first_offset"] = annotation.get("start") or 0
+
+    rows: list[dict[str, Any]] = []
+    for bucket in groups.values():
+        by_source = {source: _dedupe_hits(hits) for source, hits in bucket["by_source"].items()}
+        rows.append(
+            {
+                "keyword": bucket["keyword"],
+                "by_source": by_source,
+                "annotator_count": len(by_source),
+                "first_offset": bucket["first_offset"],
+            }
+        )
+    rows.sort(key=lambda row: (row["first_offset"], row["keyword"].casefold()))
+    return rows
+
+
+def _hit_record(annotation: dict[str, Any]) -> dict[str, Any]:
+    canonical_id = annotation.get("canonical_id")
+    return {
+        "entity_type": annotation.get("entity_type"),
+        "canonical_id": canonical_id if _is_real_canonical_id(canonical_id) else None,
+        "canonical_name": annotation.get("canonical_name"),
+        "start": annotation.get("start"),
+        "end": annotation.get("end"),
+        "confidence": annotation.get("confidence"),
+    }
+
+
+def _dedupe_hits(hits: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse hits with identical (entity_type, canonical_id, canonical_name).
+
+    Keeps the highest confidence and tracks how many mentions collapsed.
+    """
+    deduped: dict[tuple[Any, Any, Any], dict[str, Any]] = {}
+    for hit in hits:
+        key = (hit.get("entity_type"), hit.get("canonical_id"), hit.get("canonical_name"))
+        existing = deduped.get(key)
+        if existing is None:
+            deduped[key] = {**hit, "mentions": 1}
+            continue
+        existing["mentions"] += 1
+        new_conf = hit.get("confidence")
+        old_conf = existing.get("confidence")
+        if isinstance(new_conf, (int, float)) and (
+            not isinstance(old_conf, (int, float)) or new_conf > old_conf
+        ):
+            existing["confidence"] = new_conf
+    return list(deduped.values())

--- a/src/bio_annotation/report/template.html
+++ b/src/bio_annotation/report/template.html
@@ -530,24 +530,30 @@ mark.entity:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
 }
 .entity-popup-info dt { color: var(--text-muted); font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.05em; padding-top: 0.1em; }
 .entity-popup-info dd { margin: 0; word-break: break-word; }
-.entity-popup-sources { display: flex; flex-direction: column; gap: 0.7em; }
-.entity-popup-source {
-  border: 1px solid var(--border);
-  border-radius: 5px;
-  padding: 0.7em 0.9em;
-  background: var(--bg);
+.entity-popup-sources {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.4em 1.5em;
+  font-size: 0.92em;
+  align-items: start;
 }
-.entity-popup-source-name {
+.entity-popup-col-title {
+  font-size: 0.78em;
   font-weight: 600;
-  color: var(--accent);
-  font-size: 0.85em;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  margin-bottom: 0.4em;
+  color: var(--text-muted);
+  margin-bottom: 0.5em;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--border-soft);
 }
-.entity-popup-source-hits { margin: 0; padding-left: 1.2em; font-size: 0.92em; color: var(--text); }
-.entity-popup-source-hits li { margin-bottom: 0.2em; }
-.entity-popup-empty { color: var(--text-muted); font-style: italic; }
+.entity-popup-source { margin-bottom: 0.6em; }
+.entity-popup-source:last-child { margin-bottom: 0; }
+.entity-popup-source-name { font-weight: 600; color: var(--accent); }
+.entity-popup-source-id { margin: 0.1em 0 0 0.2em; }
+.entity-popup-source-none { color: var(--text-muted); }
+.entity-popup-source-detail { color: var(--text-muted); font-size: 0.9em; }
+.entity-popup-empty { grid-column: 1 / -1; color: var(--text-muted); font-style: italic; }
 
 @media (max-width: 900px) {
   .summary { grid-template-columns: 1fr; }
@@ -600,6 +606,39 @@ mark.entity:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
     flair: "Flair / HunFlair",
   };
 
+  // Display IDs with a consistent prefix casing regardless of which annotator
+  // emitted them (e.g. mesh: and MESH: both render as MESH:).
+  const ID_PREFIX_CANONICAL = {
+    mesh: "MESH",
+    ncbigene: "NCBIGene", ncbi_gene: "NCBIGene", "ncbi-gene": "NCBIGene",
+    ncbitaxon: "NCBITaxon", ncbitaxonomy: "NCBITaxon", ncbi_taxonomy: "NCBITaxon",
+    taxonomy: "NCBITaxon", taxon: "NCBITaxon",
+    dbsnp: "dbSNP", chebi: "CHEBI", drugbank: "DrugBank",
+    cellosaurus: "CVCL", cvcl: "CVCL", omim: "OMIM", mim: "OMIM",
+    cl: "CL", go: "GO", doid: "DOID", uberon: "UBERON", bto: "BTO", fma: "FMA", pato: "PATO",
+  };
+  function formatId(canonicalId, entityType) {
+    if (!canonicalId) return canonicalId;
+    const s = String(canonicalId).trim();
+    const idx = s.indexOf(":");
+    if (idx === -1) {
+      // Bare numeric id: add the prefix the prefixed annotators use, so e.g.
+      // PubTator3 "9606" matches BERN2 "NCBITaxon:9606".
+      if (/^\d+$/.test(s)) {
+        if (entityType === "gene") return "NCBIGene:" + s;
+        if (entityType === "species") return "NCBITaxon:" + s;
+      }
+      return s;
+    }
+    const canon = ID_PREFIX_CANONICAL[s.slice(0, idx).toLowerCase()];
+    return canon ? canon + ":" + s.slice(idx + 1) : s;
+  }
+  // An annotator did NEN for this entity only if it returned a usable id.
+  const NULL_IDS = new Set(["", "-", "cui-less", "none", "null"]);
+  function isRealId(id) {
+    return id != null && !NULL_IDS.has(String(id).trim().toLowerCase());
+  }
+
   function databaseLink(canonicalId, entityType) {
     if (!canonicalId) return null;
     const id = String(canonicalId).trim();
@@ -650,43 +689,81 @@ mark.entity:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
     infoEl.appendChild(dd);
   }
 
-  function renderSourceRow(name, hits, entityType) {
-    const row = document.createElement("div");
-    row.className = "entity-popup-source";
-    const heading = document.createElement("div");
-    heading.className = "entity-popup-source-name";
-    heading.textContent = ANNOTATOR_LABELS[name] || name;
-    row.appendChild(heading);
-    const list = document.createElement("ul");
-    list.className = "entity-popup-source-hits";
+  function appendDetail(parent, hit) {
+    const detail = [];
+    if (typeof hit.confidence === "number") detail.push("conf " + hit.confidence.toFixed(3));
+    const mentions = typeof hit.mentions === "number" ? hit.mentions : 1;
+    if (mentions > 1) detail.push(mentions + " mentions");
+    if (detail.length === 0) return;
+    const small = document.createElement("span");
+    small.className = "entity-popup-source-detail";
+    small.textContent = " (" + detail.join(", ") + ")";
+    parent.appendChild(small);
+  }
+
+  // An annotator counts as NEN for this entity if any of its hits has a real id.
+  function annotatorIsNen(hits) {
+    return hits.some((h) => isRealId(h.canonical_id));
+  }
+
+  // Left ("NEN") column: annotator name plus each normalized id/name.
+  function renderNenEntry(name, hits, entityType) {
+    const div = document.createElement("div");
+    div.className = "entity-popup-source";
+    const nm = document.createElement("div");
+    nm.className = "entity-popup-source-name";
+    nm.textContent = ANNOTATOR_LABELS[name] || name;
+    div.appendChild(nm);
     for (const hit of hits) {
-      const li = document.createElement("li");
-      if (hit.canonical_id) {
-        const link = databaseLink(hit.canonical_id, entityType);
-        li.appendChild(document.createTextNode("ID: "));
-        if (link) {
-          const a = document.createElement("a");
-          a.href = link.url; a.target = "_blank"; a.rel = "noopener";
-          a.textContent = hit.canonical_id;
-          li.appendChild(a);
-        } else {
-          li.appendChild(document.createTextNode(hit.canonical_id));
-        }
+      if (!isRealId(hit.canonical_id)) continue;
+      const line = document.createElement("div");
+      line.className = "entity-popup-source-id";
+      const link = databaseLink(hit.canonical_id, entityType);
+      if (link) {
+        const a = document.createElement("a");
+        a.href = link.url; a.target = "_blank"; a.rel = "noopener";
+        a.textContent = formatId(hit.canonical_id, entityType);
+        line.appendChild(a);
+      } else {
+        line.appendChild(document.createTextNode(formatId(hit.canonical_id, entityType)));
       }
-      const tail = [];
-      if (hit.canonical_name) tail.push(`name: ${hit.canonical_name}`);
-      if (typeof hit.confidence === "number") tail.push(`confidence: ${hit.confidence.toFixed(3)}`);
-      const mentions = typeof hit.mentions === "number" ? hit.mentions : 1;
-      if (mentions > 1) tail.push(`${mentions} mentions`);
-      if (!hit.canonical_id && tail.length === 0) tail.push("tagged, no canonical id");
-      if (tail.length > 0) {
-        const prefix = hit.canonical_id ? " · " : "";
-        li.appendChild(document.createTextNode(prefix + tail.join(" · ")));
+      if (hit.canonical_name && hit.canonical_name !== hit.canonical_id) {
+        line.appendChild(document.createTextNode(" · " + hit.canonical_name));
       }
-      list.appendChild(li);
+      appendDetail(line, hit);
+      div.appendChild(line);
     }
-    row.appendChild(list);
-    return row;
+    return div;
+  }
+
+  // Right ("NER only") column: annotator name and detail, no id.
+  function renderNerEntry(name, hits) {
+    const div = document.createElement("div");
+    div.className = "entity-popup-source";
+    const nm = document.createElement("span");
+    nm.className = "entity-popup-source-name";
+    nm.textContent = ANNOTATOR_LABELS[name] || name;
+    div.appendChild(nm);
+    if (hits.length > 0) appendDetail(div, hits[0]);
+    return div;
+  }
+
+  function renderColumn(title, names, renderEntry) {
+    const col = document.createElement("div");
+    col.className = "entity-popup-col";
+    const heading = document.createElement("div");
+    heading.className = "entity-popup-col-title";
+    heading.textContent = title;
+    col.appendChild(heading);
+    if (names.length === 0) {
+      const none = document.createElement("div");
+      none.className = "entity-popup-source-none";
+      none.textContent = "-";
+      col.appendChild(none);
+    } else {
+      for (const n of names) col.appendChild(renderEntry(n));
+    }
+    return col;
   }
 
   function openPopup(mark) {
@@ -699,7 +776,7 @@ mark.entity:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
     appendInfo("Keyword", data.keyword);
     appendInfo("Canonical name", data.canonical_name);
     const idLink = databaseLink(data.canonical_id, data.entity_type);
-    appendInfo("Canonical id", data.canonical_id, idLink ? idLink.url : null);
+    appendInfo("Canonical id", formatId(data.canonical_id, data.entity_type), idLink ? idLink.url : null);
 
     const sources = data.by_source || {};
     // Shows annotators in this order: PubTator3, then BERN2, then Flair.
@@ -712,9 +789,13 @@ mark.entity:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
       note.textContent = "No annotator details available.";
       sourcesEl.appendChild(note);
     } else {
-      for (const name of names) {
-        sourcesEl.appendChild(renderSourceRow(name, sources[name], data.entity_type));
-      }
+      // Split by whether each annotator normalized THIS entity (NEN) or only
+      // tagged it (NER only). The same annotator (e.g. BERN2) can fall in either
+      // column depending on the entity.
+      const nenNames = names.filter((n) => annotatorIsNen(sources[n]));
+      const nerNames = names.filter((n) => !annotatorIsNen(sources[n]));
+      sourcesEl.appendChild(renderColumn("NEN", nenNames, (n) => renderNenEntry(n, sources[n], data.entity_type)));
+      sourcesEl.appendChild(renderColumn("NER only", nerNames, (n) => renderNerEntry(n, sources[n])));
     }
     popup.classList.remove("hidden");
     popup.setAttribute("aria-hidden", "false");

--- a/src/bio_annotation/report/template.html
+++ b/src/bio_annotation/report/template.html
@@ -1,0 +1,724 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>TotalAnnotator results</title>
+<style>
+:root {
+  --bg: #f6f4f9;
+  --bg-card: #ffffff;
+  --text: #1f1d2b;
+  --text-muted: #6b6878;
+  --text-soft: #8c8aa1;
+  --border: #e3dfee;
+  --border-soft: #efeaf6;
+  --accent: #4a3c8f;
+  --accent-soft: #6c5fb5;
+  --accent-bg: #ece7f7;
+  --serif: Georgia, "Iowan Old Style", "Palatino Linotype", Palatino, serif;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, system-ui, sans-serif;
+}
+* { box-sizing: border-box; }
+body {
+  font-family: var(--sans);
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 1.5em 4em;
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.55;
+}
+h1, h2, h3, h4 {
+  font-family: var(--serif);
+  color: var(--text);
+  letter-spacing: -0.01em;
+  font-weight: 600;
+}
+h1 { font-size: 2em; margin: 0; }
+h2 { font-size: 1.55em; margin: 0.4em 0 0.2em; }
+h3 { font-size: 1.05em; margin: 2em 0 0.5em; text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent); font-weight: 700; font-family: var(--sans); }
+h4 { font-size: 0.78em; margin: 0 0 0.8em; text-transform: uppercase; letter-spacing: 0.12em; color: var(--accent); font-weight: 700; font-family: var(--sans); }
+a { color: var(--accent); text-decoration: none; border-bottom: 1px solid transparent; transition: border-color 120ms; }
+a:hover { border-bottom-color: var(--accent); }
+
+.site-header {
+  padding: 2em 0 1em;
+  margin-bottom: 1.5em;
+  border-bottom: 1px solid var(--border);
+}
+.site-header h1 { font-family: var(--serif); color: var(--accent); }
+.site-header p { margin: 0.4em 0 0; color: var(--text-muted); font-size: 0.95em; font-style: italic; }
+
+.summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 2em;
+  align-items: center;
+  margin-bottom: 2em;
+  padding: 1.6em 1.8em;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(31, 29, 43, 0.04);
+}
+.summary-headline .lede { font-size: 1.1em; margin: 0 0 0.3em; color: var(--text-muted); }
+.summary-headline .meta { margin: 0; color: var(--text-soft); font-size: 0.92em; }
+.big-number { font-family: var(--serif); color: var(--accent); font-size: 1.6em; font-weight: 700; padding: 0 0.05em; }
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
+  margin-bottom: 2em;
+  font-size: 0.82em;
+  color: var(--text-muted);
+}
+.legend-chip {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 2px;
+  font-family: var(--serif);
+  cursor: default;
+  user-select: none;
+}
+.legend-chip-gene      { background: #cfe8c9; color: #235c27; }
+.legend-chip-disease   { background: #f6cccb; color: #7a2a2a; }
+.legend-chip-drug      { background: #fbddae; color: #6b4310; }
+.legend-chip-species   { background: #c6d9f6; color: #1f4a82; }
+.legend-chip-variant   { background: #ecc8ec; color: #6a2f7a; }
+.legend-chip-cell_line { background: #d3c4f0; color: #45308f; }
+.legend-chip-dna       { background: #b6e6da; color: #0f5d51; }
+.legend-chip-rna       { background: #f1e59f; color: #6b5810; }
+.legend-chip-cell_type { background: #e0d3c2; color: #5e4630; }
+.legend-chip-unmatched { background: #fbeb8a; color: #5c4910; }
+
+.hint {
+  font-size: 0.9em;
+  color: var(--text-muted);
+  margin: 0 0 0.8em;
+}
+
+.document {
+  margin-bottom: 1.2em;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-card);
+}
+.document > summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  align-items: baseline;
+  gap: 0.7em;
+  padding: 1em 1.3em;
+}
+.document > summary::-webkit-details-marker { display: none; }
+.document > summary::before {
+  content: "▸";
+  color: var(--text-soft);
+  display: inline-block;
+  transition: transform 120ms;
+}
+.document[open] > summary::before { transform: rotate(90deg); }
+.document > summary:hover { background: var(--border-soft); }
+.doc-summary-title { font-family: var(--serif); font-weight: 700; font-size: 1.08em; flex: 1; color: var(--text); }
+.doc-summary-count { color: var(--text-muted); font-size: 0.85em; white-space: nowrap; }
+.doc-body { padding: 0 1.3em 1.4em; }
+.document .meta { font-size: 0.88em; color: var(--text-muted); margin-top: 0.1em; }
+
+.doc-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 2em;
+  margin-top: 1em;
+  align-items: start;
+}
+.doc-main > h3:first-child { margin-top: 0; }
+.doc-main { min-width: 0; }
+
+.annotated-text {
+  background: var(--bg-card);
+  padding: 1.6em 1.8em;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  line-height: 1.85;
+  font-size: 1em;
+  font-family: var(--serif);
+  color: var(--text);
+}
+
+mark.entity {
+  padding: 1px 4px;
+  border-radius: 2px;
+  font-family: var(--serif);
+  cursor: pointer;
+  border-bottom: 1px dotted transparent;
+  transition: border-bottom-color 120ms;
+}
+mark.entity:hover { border-bottom-color: rgba(31, 29, 43, 0.4); }
+mark.entity           { background: transparent; }
+mark.entity-gene      { background: #cfe8c9; color: #235c27; }
+mark.entity-disease   { background: #f6cccb; color: #7a2a2a; }
+mark.entity-drug      { background: #fbddae; color: #6b4310; }
+mark.entity-species   { background: #c6d9f6; color: #1f4a82; }
+mark.entity-variant   { background: #ecc8ec; color: #6a2f7a; }
+mark.entity-cell_line { background: #d3c4f0; color: #45308f; }
+mark.entity-dna       { background: #b6e6da; color: #0f5d51; }
+mark.entity-rna       { background: #f1e59f; color: #6b5810; }
+mark.entity-cell_type { background: #e0d3c2; color: #5e4630; }
+mark.entity-unknown   { background: #e6e3ec; color: var(--text-muted); }
+mark.entity-unmatched { background: #fbeb8a; color: #5c4910; border-bottom: 1px dashed #b8941c; }
+mark.entity:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.stats-panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1.3em 1.4em;
+  align-self: start;
+  box-shadow: 0 1px 3px rgba(31, 29, 43, 0.04);
+}
+.stats-panel h4 { margin-bottom: 1em; }
+.stats-group { margin-bottom: 0.3em; }
+.stats-group:last-of-type { margin-bottom: 0; }
+.stats-group summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0.5em 0;
+  border-bottom: 1px solid var(--border-soft);
+  cursor: pointer;
+  list-style: none;
+  outline: none;
+}
+.stats-group summary::-webkit-details-marker { display: none; }
+.stats-group summary::before {
+  content: "▸";
+  display: inline-block;
+  margin-right: 0.4em;
+  color: var(--text-soft);
+  font-size: 0.7em;
+  transform: translateY(-1px);
+  transition: transform 120ms;
+}
+.stats-group[open] summary::before { transform: rotate(90deg) translateX(-1px); }
+.stats-group summary:hover { background: var(--border-soft); }
+.stats-type {
+  font-size: 0.78em;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 700;
+  flex: 1;
+}
+.stats-group-disease .stats-type   { color: #8c3a3a; }
+.stats-group-drug .stats-type      { color: #846213; }
+.stats-group-gene .stats-type      { color: #3a5b32; }
+.stats-group-species .stats-type   { color: #34557a; }
+.stats-group-variant .stats-type   { color: #7e3a55; }
+.stats-group-cell_line .stats-type { color: #4a3a73; }
+.stats-type-total {
+  font-size: 0.78em;
+  color: var(--text-soft);
+  font-variant-numeric: tabular-nums;
+}
+.stats-list {
+  list-style: none;
+  padding: 0.5em 0 0.2em 1.2em;
+  margin: 0;
+  font-size: 0.92em;
+}
+.stats-list li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 70px max-content;
+  align-items: center;
+  gap: 0.6em;
+  padding: 0.22em 0;
+}
+.stats-keyword {
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.stats-bar-track {
+  height: 5px;
+  background: var(--border-soft);
+  border-radius: 3px;
+  overflow: hidden;
+  width: 100%;
+}
+.stats-bar-fill {
+  display: block;
+  height: 100%;
+  background: var(--accent-soft);
+  border-radius: 3px;
+  transition: width 200ms;
+}
+.stats-group-disease .stats-bar-fill   { background: #c96b6b; }
+.stats-group-drug .stats-bar-fill      { background: #d99a3e; }
+.stats-group-gene .stats-bar-fill      { background: #5fa052; }
+.stats-group-species .stats-bar-fill   { background: #5a86c4; }
+.stats-group-variant .stats-bar-fill   { background: #b25fb2; }
+.stats-group-cell_line .stats-bar-fill { background: #7d5fc4; }
+.stats-group-dna .stats-bar-fill       { background: #2fa899; }
+.stats-group-rna .stats-bar-fill       { background: #c9b03e; }
+.stats-group-cell_type .stats-bar-fill { background: #9c7a52; }
+.stats-count {
+  color: var(--text-soft);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.85em;
+  text-align: right;
+  min-width: 1.5em;
+}
+.stats-more { color: var(--text-soft); font-style: italic; font-size: 0.85em; padding-top: 0.4em; }
+
+.chart-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1.3em 1.6em 1.5em;
+  margin-bottom: 1.5em;
+  box-shadow: 0 1px 3px rgba(31, 29, 43, 0.04);
+}
+.chart-card h4 { margin: 0 0 1em 0; }
+
+.type-histogram { list-style: none; margin: 0; padding: 0; }
+.hist-row {
+  display: grid;
+  grid-template-columns: 130px minmax(0, 1fr) 50px;
+  align-items: center;
+  gap: 0.9em;
+  padding: 0.35em 0;
+}
+.hist-label {
+  font-size: 0.82em;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+.hist-row-disease .hist-label   { color: #8c3a3a; }
+.hist-row-drug .hist-label      { color: #846213; }
+.hist-row-gene .hist-label      { color: #3a5b32; }
+.hist-row-species .hist-label   { color: #34557a; }
+.hist-row-variant .hist-label   { color: #7e3a55; }
+.hist-row-cell_line .hist-label { color: #4a3a73; }
+.hist-track {
+  height: 10px;
+  background: var(--border-soft);
+  border-radius: 5px;
+  overflow: hidden;
+}
+.hist-fill {
+  display: block;
+  height: 100%;
+  border-radius: 5px;
+  background: var(--accent-soft);
+  transition: width 250ms ease-out;
+}
+.hist-row-disease .hist-fill   { background: #c96b6b; }
+.hist-row-drug .hist-fill      { background: #d99a3e; }
+.hist-row-gene .hist-fill      { background: #5fa052; }
+.hist-row-species .hist-fill   { background: #5a86c4; }
+.hist-row-variant .hist-fill   { background: #b25fb2; }
+.hist-row-cell_line .hist-fill { background: #7d5fc4; }
+.hist-row-dna .hist-fill       { background: #2fa899; }
+.hist-row-rna .hist-fill       { background: #c9b03e; }
+.hist-row-cell_type .hist-fill { background: #9c7a52; }
+.hist-count {
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+  text-align: right;
+  font-weight: 600;
+}
+
+.doc-overview { list-style: none; margin: 0; padding: 0; }
+.doc-row {
+  display: grid;
+  grid-template-columns: 110px minmax(0, 1fr) minmax(160px, 30%) 50px;
+  align-items: center;
+  gap: 0.8em;
+  padding: 0.45em 0;
+  border-bottom: 1px solid var(--border-soft);
+}
+.doc-row:last-child { border-bottom: none; }
+.doc-link {
+  font-size: 0.85em;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.doc-title {
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-style: italic;
+}
+.doc-track {
+  height: 12px;
+  background: var(--border-soft);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.doc-bar {
+  display: flex;
+  height: 100%;
+  border-radius: 6px;
+  overflow: hidden;
+}
+.doc-seg { display: block; height: 100%; }
+.doc-seg-disease   { background: #c96b6b; }
+.doc-seg-drug      { background: #d99a3e; }
+.doc-seg-gene      { background: #5fa052; }
+.doc-seg-species   { background: #5a86c4; }
+.doc-seg-variant   { background: #b25fb2; }
+.doc-seg-cell_line { background: #7d5fc4; }
+.doc-seg-dna       { background: #2fa899; }
+.doc-seg-rna       { background: #c9b03e; }
+.doc-seg-cell_type { background: #9c7a52; }
+.doc-seg-rna       { background: #5e8b8f; }
+.doc-seg-dna       { background: #88a0a3; }
+.doc-seg-cell_type { background: #ae7c92; }
+.doc-seg-unknown   { background: var(--text-soft); }
+.doc-count {
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+  font-weight: 600;
+  text-align: right;
+}
+
+.comparison-section { margin-top: 1.5em; }
+.comparison-section summary {
+  display: flex;
+  align-items: baseline;
+  gap: 1em;
+  cursor: pointer;
+  list-style: none;
+  outline: none;
+  padding: 0.4em 0;
+}
+.comparison-section summary::-webkit-details-marker { display: none; }
+.comparison-section summary h3 { margin: 0; }
+.comparison-section summary::after {
+  content: "▸";
+  color: var(--text-soft);
+  margin-left: auto;
+  font-size: 0.85em;
+  transition: transform 120ms;
+}
+.comparison-section[open] summary::after { transform: rotate(90deg); }
+.comparison-section[open] summary .hint { color: var(--text-muted); }
+.comparison-section .hint { margin: 0; }
+.comparison-scroll {
+  max-height: 60vh;
+  overflow-y: auto;
+  margin-top: 0.8em;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-card);
+}
+.comparison-scroll .comparison { border: none; border-radius: 0; }
+.comparison-scroll thead { position: sticky; top: 0; z-index: 1; }
+
+.comparison {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  font-size: 0.92em;
+}
+.comparison th, .comparison td {
+  text-align: left;
+  padding: 0.7em 1em;
+  border-bottom: 1px solid var(--border-soft);
+  vertical-align: top;
+}
+.comparison tr:last-child td { border-bottom: none; }
+.comparison th {
+  background: var(--accent-bg);
+  color: var(--accent);
+  font-size: 0.78em;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+}
+.comparison code {
+  background: var(--accent-bg);
+  color: var(--accent);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.88em;
+}
+.comparison .entity-type {
+  font-weight: 600;
+  font-size: 0.92em;
+}
+.comparison .absent { color: var(--text-soft); }
+.comparison small { color: var(--text-muted); font-size: 0.85em; }
+
+.entity-popup-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(31, 29, 43, 0.55);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 8vh 1em 1em;
+  z-index: 1000;
+  backdrop-filter: blur(2px);
+}
+.entity-popup-overlay.hidden { display: none; }
+.entity-popup-card {
+  background: var(--bg-card);
+  border-radius: 8px;
+  box-shadow: 0 20px 50px rgba(31, 29, 43, 0.3);
+  width: min(560px, 100%);
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 1.4em 1.6em 1.6em;
+}
+.entity-popup-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1em;
+  border-bottom: 1px solid var(--border-soft);
+  padding-bottom: 0.8em;
+  margin-bottom: 1em;
+}
+.entity-popup-header h3 { margin: 0; text-transform: none; letter-spacing: 0; font-family: var(--serif); font-size: 1.3em; color: var(--text); }
+.entity-popup-close {
+  background: transparent;
+  color: var(--text-muted);
+  border: none;
+  font-size: 1.5em;
+  line-height: 1;
+  padding: 0 0.2em;
+  cursor: pointer;
+  font-family: var(--sans);
+}
+.entity-popup-close:hover { color: var(--accent); }
+.entity-popup-info {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.4em 1.2em;
+  margin: 0 0 1.2em 0;
+  font-size: 0.95em;
+}
+.entity-popup-info dt { color: var(--text-muted); font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.05em; padding-top: 0.1em; }
+.entity-popup-info dd { margin: 0; word-break: break-word; }
+.entity-popup-sources { display: flex; flex-direction: column; gap: 0.7em; }
+.entity-popup-source {
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 0.7em 0.9em;
+  background: var(--bg);
+}
+.entity-popup-source-name {
+  font-weight: 600;
+  color: var(--accent);
+  font-size: 0.85em;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.4em;
+}
+.entity-popup-source-hits { margin: 0; padding-left: 1.2em; font-size: 0.92em; color: var(--text); }
+.entity-popup-source-hits li { margin-bottom: 0.2em; }
+.entity-popup-empty { color: var(--text-muted); font-style: italic; }
+
+@media (max-width: 900px) {
+  .summary { grid-template-columns: 1fr; }
+  .doc-grid { grid-template-columns: 1fr; }
+  .stats-panel { order: 2; }
+}
+</style>
+</head>
+<body>
+<header class="site-header">
+  <h1>TotalAnnotator</h1>
+  <p>Static annotation report. Re-open this file any time to revisit the run.</p>
+</header>
+
+<!--CONTENT-->
+
+<div class="entity-popup-overlay hidden" id="entity-popup" aria-hidden="true" role="dialog">
+  <div class="entity-popup-card">
+    <div class="entity-popup-header">
+      <h3 id="entity-popup-title">Entity</h3>
+      <button class="entity-popup-close" type="button" aria-label="Close">&times;</button>
+    </div>
+    <dl class="entity-popup-info"></dl>
+    <h4>Found by</h4>
+    <div class="entity-popup-sources"></div>
+  </div>
+</div>
+
+<script>
+(() => {
+  const popup = document.getElementById("entity-popup");
+  if (!popup) return;
+  const titleEl = popup.querySelector("#entity-popup-title");
+  const infoEl = popup.querySelector(".entity-popup-info");
+  const sourcesEl = popup.querySelector(".entity-popup-sources");
+  const closeBtn = popup.querySelector(".entity-popup-close");
+
+  const ENTITY_TYPE_LABELS = {
+    gene: "Gene / protein",
+    disease: "Disease",
+    drug: "Chemical / drug",
+    species: "Species",
+    variant: "Variant / mutation",
+    cell_line: "Cell line",
+    unknown: "Entity",
+  };
+  const ANNOTATOR_LABELS = {
+    pubtator3: "PubTator3",
+    bern2: "BERN2",
+    flair: "Flair / HunFlair",
+  };
+
+  function databaseLink(canonicalId, entityType) {
+    if (!canonicalId) return null;
+    const id = String(canonicalId).trim();
+    const mesh = id.match(/^mesh:(.+)$/i);
+    if (mesh) return { url: `https://meshb.nlm.nih.gov/record/ui?ui=${encodeURIComponent(mesh[1])}` };
+    const gene = id.match(/^ncbi[_-]?gene:(.+)$/i);
+    if (gene) return { url: `https://www.ncbi.nlm.nih.gov/gene/${encodeURIComponent(gene[1])}` };
+    const tax = id.match(/^(?:ncbi[_-]?taxonomy|ncbitaxon|taxonomy|taxon):(.+)$/i);
+    if (tax) return { url: `https://www.ncbi.nlm.nih.gov/taxonomy/${encodeURIComponent(tax[1])}` };
+    const snp = id.match(/^(?:dbsnp|rs):(.+)$/i);
+    if (snp) return { url: `https://www.ncbi.nlm.nih.gov/snp/${encodeURIComponent(snp[1])}` };
+    const chebi = id.match(/^chebi:(.+)$/i);
+    if (chebi) return { url: `https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:${encodeURIComponent(chebi[1])}` };
+    const drugbank = id.match(/^drugbank:(.+)$/i);
+    if (drugbank) return { url: `https://go.drugbank.com/drugs/${encodeURIComponent(drugbank[1])}` };
+    const cvcl = id.match(/^(?:cellosaurus|cvcl):(.+)$/i);
+    if (cvcl) {
+      const ref = cvcl[1].startsWith("CVCL_") ? cvcl[1] : `CVCL_${cvcl[1]}`;
+      return { url: `https://www.cellosaurus.org/${encodeURIComponent(ref)}` };
+    }
+    const omim = id.match(/^(?:omim|mim):(.+)$/i);
+    if (omim) return { url: `https://www.omim.org/entry/${encodeURIComponent(omim[1])}` };
+    if (entityType === "gene" && /^\d+$/.test(id)) {
+      return { url: `https://www.ncbi.nlm.nih.gov/gene/${encodeURIComponent(id)}` };
+    }
+    if (entityType === "species" && /^\d+$/.test(id)) {
+      return { url: `https://www.ncbi.nlm.nih.gov/taxonomy/${encodeURIComponent(id)}` };
+    }
+    const obo = id.match(/^(cl|go|doid|uberon|bto|fma|pato):(.+)$/i);
+    if (obo) return { url: `https://purl.obolibrary.org/obo/${obo[1].toUpperCase()}_${encodeURIComponent(obo[2])}` };
+    return null;
+  }
+
+  function appendInfo(label, value, link) {
+    if (value === null || value === undefined || value === "") return;
+    const dt = document.createElement("dt");
+    dt.textContent = label;
+    const dd = document.createElement("dd");
+    if (link) {
+      const anchor = document.createElement("a");
+      anchor.href = link; anchor.target = "_blank"; anchor.rel = "noopener";
+      anchor.textContent = value;
+      dd.appendChild(anchor);
+    } else {
+      dd.textContent = value;
+    }
+    infoEl.appendChild(dt);
+    infoEl.appendChild(dd);
+  }
+
+  function renderSourceRow(name, hits, entityType) {
+    const row = document.createElement("div");
+    row.className = "entity-popup-source";
+    const heading = document.createElement("div");
+    heading.className = "entity-popup-source-name";
+    heading.textContent = ANNOTATOR_LABELS[name] || name;
+    row.appendChild(heading);
+    const list = document.createElement("ul");
+    list.className = "entity-popup-source-hits";
+    for (const hit of hits) {
+      const li = document.createElement("li");
+      if (hit.canonical_id) {
+        const link = databaseLink(hit.canonical_id, entityType);
+        li.appendChild(document.createTextNode("ID: "));
+        if (link) {
+          const a = document.createElement("a");
+          a.href = link.url; a.target = "_blank"; a.rel = "noopener";
+          a.textContent = hit.canonical_id;
+          li.appendChild(a);
+        } else {
+          li.appendChild(document.createTextNode(hit.canonical_id));
+        }
+      }
+      const tail = [];
+      if (hit.canonical_name) tail.push(`name: ${hit.canonical_name}`);
+      if (typeof hit.confidence === "number") tail.push(`confidence: ${hit.confidence.toFixed(3)}`);
+      const mentions = typeof hit.mentions === "number" ? hit.mentions : 1;
+      if (mentions > 1) tail.push(`${mentions} mentions`);
+      if (!hit.canonical_id && tail.length === 0) tail.push("tagged, no canonical id");
+      if (tail.length > 0) {
+        const prefix = hit.canonical_id ? " · " : "";
+        li.appendChild(document.createTextNode(prefix + tail.join(" · ")));
+      }
+      list.appendChild(li);
+    }
+    row.appendChild(list);
+    return row;
+  }
+
+  function openPopup(mark) {
+    let data;
+    try { data = JSON.parse(mark.dataset.entity || "{}"); }
+    catch (err) { console.error("Failed to parse entity data", err); return; }
+    titleEl.textContent = ENTITY_TYPE_LABELS[data.entity_type] || data.entity_type || "Entity";
+    infoEl.innerHTML = "";
+    sourcesEl.innerHTML = "";
+    appendInfo("Keyword", data.keyword);
+    appendInfo("Canonical name", data.canonical_name);
+    const idLink = databaseLink(data.canonical_id, data.entity_type);
+    appendInfo("Canonical id", data.canonical_id, idLink ? idLink.url : null);
+
+    const sources = data.by_source || {};
+    // Shows annotators in this order: PubTator3, then BERN2, then Flair.
+    const SOURCE_ORDER = { pubtator3: 0, bern2: 1, flair: 2 };
+    const rank = (n) => (n in SOURCE_ORDER ? SOURCE_ORDER[n] : 99);
+    const names = Object.keys(sources).sort((a, b) => rank(a) - rank(b) || a.localeCompare(b));
+    if (names.length === 0) {
+      const note = document.createElement("p");
+      note.className = "entity-popup-empty";
+      note.textContent = "No annotator details available.";
+      sourcesEl.appendChild(note);
+    } else {
+      for (const name of names) {
+        sourcesEl.appendChild(renderSourceRow(name, sources[name], data.entity_type));
+      }
+    }
+    popup.classList.remove("hidden");
+    popup.setAttribute("aria-hidden", "false");
+    closeBtn.focus();
+  }
+  function closePopup() {
+    popup.classList.add("hidden");
+    popup.setAttribute("aria-hidden", "true");
+  }
+
+  document.addEventListener("click", (event) => {
+    const mark = event.target.closest("mark.entity");
+    if (mark && mark.dataset.entity) { event.preventDefault(); openPopup(mark); return; }
+    if (event.target === popup) closePopup();
+  });
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      const mark = event.target.closest && event.target.closest("mark.entity");
+      if (mark && mark.dataset.entity) { event.preventDefault(); openPopup(mark); }
+    }
+    if (event.key === "Escape" && !popup.classList.contains("hidden")) closePopup();
+  });
+  closeBtn.addEventListener("click", closePopup);
+})();
+</script>
+</body>
+</html>

--- a/src/bio_annotation/report/template.html
+++ b/src/bio_annotation/report/template.html
@@ -210,12 +210,15 @@ mark.entity:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
   font-weight: 700;
   flex: 1;
 }
-.stats-group-disease .stats-type   { color: #8c3a3a; }
-.stats-group-drug .stats-type      { color: #846213; }
-.stats-group-gene .stats-type      { color: #3a5b32; }
-.stats-group-species .stats-type   { color: #34557a; }
-.stats-group-variant .stats-type   { color: #7e3a55; }
-.stats-group-cell_line .stats-type { color: #4a3a73; }
+.stats-group-disease .stats-type   { color: #b35a5a; }
+.stats-group-drug .stats-type      { color: #9c7321; }
+.stats-group-gene .stats-type      { color: #5f8a52; }
+.stats-group-species .stats-type   { color: #4f7aac; }
+.stats-group-variant .stats-type   { color: #9c5172; }
+.stats-group-cell_line .stats-type { color: #6a5aa0; }
+.stats-group-dna .stats-type       { color: #2f8f80; }
+.stats-group-rna .stats-type       { color: #9c842a; }
+.stats-group-cell_type .stats-type { color: #876b4a; }
 .stats-type-total {
   font-size: 0.78em;
   color: var(--text-soft);
@@ -235,10 +238,14 @@ mark.entity:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
   padding: 0.22em 0;
 }
 .stats-keyword {
+  justify-self: start;
+  max-width: 100%;
   color: var(--text);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  padding: 0.05em 0.4em;
+  border-radius: 3px;
 }
 .stats-bar-track {
   height: 5px;
@@ -254,15 +261,25 @@ mark.entity:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
   border-radius: 3px;
   transition: width 200ms;
 }
-.stats-group-disease .stats-bar-fill   { background: #c96b6b; }
-.stats-group-drug .stats-bar-fill      { background: #d99a3e; }
-.stats-group-gene .stats-bar-fill      { background: #5fa052; }
-.stats-group-species .stats-bar-fill   { background: #5a86c4; }
-.stats-group-variant .stats-bar-fill   { background: #b25fb2; }
-.stats-group-cell_line .stats-bar-fill { background: #7d5fc4; }
-.stats-group-dna .stats-bar-fill       { background: #2fa899; }
-.stats-group-rna .stats-bar-fill       { background: #c9b03e; }
-.stats-group-cell_type .stats-bar-fill { background: #9c7a52; }
+.stats-group-disease .stats-bar-fill   { background: #eaa9a8; }
+.stats-group-drug .stats-bar-fill      { background: #f2c47c; }
+.stats-group-gene .stats-bar-fill      { background: #a6d49b; }
+.stats-group-species .stats-bar-fill   { background: #9fbeea; }
+.stats-group-variant .stats-bar-fill   { background: #d9a7d9; }
+.stats-group-cell_line .stats-bar-fill { background: #b7a3e5; }
+.stats-group-dna .stats-bar-fill       { background: #8ad6c4; }
+.stats-group-rna .stats-bar-fill       { background: #e2d06a; }
+.stats-group-cell_type .stats-bar-fill { background: #ccb89c; }
+/* Each bioconcept carries the same highlight color it has in the text. */
+.stats-group-gene      .stats-keyword { background: #cfe8c9; color: #235c27; }
+.stats-group-disease   .stats-keyword { background: #f6cccb; color: #7a2a2a; }
+.stats-group-drug      .stats-keyword { background: #fbddae; color: #6b4310; }
+.stats-group-species   .stats-keyword { background: #c6d9f6; color: #1f4a82; }
+.stats-group-variant   .stats-keyword { background: #ecc8ec; color: #6a2f7a; }
+.stats-group-cell_line .stats-keyword { background: #d3c4f0; color: #45308f; }
+.stats-group-dna       .stats-keyword { background: #b6e6da; color: #0f5d51; }
+.stats-group-rna       .stats-keyword { background: #f1e59f; color: #6b5810; }
+.stats-group-cell_type .stats-keyword { background: #e0d3c2; color: #5e4630; }
 .stats-count {
   color: var(--text-soft);
   font-variant-numeric: tabular-nums;
@@ -297,12 +314,15 @@ mark.entity:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
   font-weight: 700;
   color: var(--text-muted);
 }
-.hist-row-disease .hist-label   { color: #8c3a3a; }
-.hist-row-drug .hist-label      { color: #846213; }
-.hist-row-gene .hist-label      { color: #3a5b32; }
-.hist-row-species .hist-label   { color: #34557a; }
-.hist-row-variant .hist-label   { color: #7e3a55; }
-.hist-row-cell_line .hist-label { color: #4a3a73; }
+.hist-row-disease .hist-label   { color: #b35a5a; }
+.hist-row-drug .hist-label      { color: #9c7321; }
+.hist-row-gene .hist-label      { color: #5f8a52; }
+.hist-row-species .hist-label   { color: #4f7aac; }
+.hist-row-variant .hist-label   { color: #9c5172; }
+.hist-row-cell_line .hist-label { color: #6a5aa0; }
+.hist-row-dna .hist-label       { color: #2f8f80; }
+.hist-row-rna .hist-label       { color: #9c842a; }
+.hist-row-cell_type .hist-label { color: #876b4a; }
 .hist-track {
   height: 10px;
   background: var(--border-soft);
@@ -316,15 +336,15 @@ mark.entity:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
   background: var(--accent-soft);
   transition: width 250ms ease-out;
 }
-.hist-row-disease .hist-fill   { background: #c96b6b; }
-.hist-row-drug .hist-fill      { background: #d99a3e; }
-.hist-row-gene .hist-fill      { background: #5fa052; }
-.hist-row-species .hist-fill   { background: #5a86c4; }
-.hist-row-variant .hist-fill   { background: #b25fb2; }
-.hist-row-cell_line .hist-fill { background: #7d5fc4; }
-.hist-row-dna .hist-fill       { background: #2fa899; }
-.hist-row-rna .hist-fill       { background: #c9b03e; }
-.hist-row-cell_type .hist-fill { background: #9c7a52; }
+.hist-row-disease .hist-fill   { background: #eaa9a8; }
+.hist-row-drug .hist-fill      { background: #f2c47c; }
+.hist-row-gene .hist-fill      { background: #a6d49b; }
+.hist-row-species .hist-fill   { background: #9fbeea; }
+.hist-row-variant .hist-fill   { background: #d9a7d9; }
+.hist-row-cell_line .hist-fill { background: #b7a3e5; }
+.hist-row-dna .hist-fill       { background: #8ad6c4; }
+.hist-row-rna .hist-fill       { background: #e2d06a; }
+.hist-row-cell_type .hist-fill { background: #ccb89c; }
 .hist-count {
   font-variant-numeric: tabular-nums;
   color: var(--text);

--- a/src/bio_annotation/terminal_ui.py
+++ b/src/bio_annotation/terminal_ui.py
@@ -27,7 +27,6 @@ from bio_annotation.pipeline_runner import (
     run_pipeline_from_config,
     write_pipeline_tsv_outputs,
 )
-from bio_annotation.report import write_html_report
 from bio_annotation.terminal_text_input import (
     GENERATED_TEXT_DOCUMENT_ID,
     is_text_table_file,
@@ -100,7 +99,9 @@ def run_terminal_annotation_ui(
     pipeline_results_path = (
         Path(output_info["path"]) if output_info and output_info.get("path") else paths.results_path
     )
-    report_path = write_html_report(payload, pipeline_results_path.with_suffix(".html"))
+    # The report is written by the shared writer (write_pipeline_output); here we
+    # only resolve its path to display it.
+    report_path = pipeline_results_path.with_suffix(".html")
     output_fn("")
     output_fn("Run complete")
     output_fn(f"Documents: {payload.get('document_count', 0)}")

--- a/src/bio_annotation/terminal_ui.py
+++ b/src/bio_annotation/terminal_ui.py
@@ -27,6 +27,7 @@ from bio_annotation.pipeline_runner import (
     run_pipeline_from_config,
     write_pipeline_tsv_outputs,
 )
+from bio_annotation.report import write_html_report
 from bio_annotation.terminal_text_input import (
     GENERATED_TEXT_DOCUMENT_ID,
     is_text_table_file,
@@ -95,6 +96,11 @@ def run_terminal_annotation_ui(
     payload = pipeline_run_fn(paths.config_path)
     write_pipeline_tsv_outputs(payload, paths.results_path)
     write_json(paths.manifest_path, build_run_manifest(answers, paths, payload))
+    output_info = payload.get("output") if isinstance(payload.get("output"), dict) else None
+    pipeline_results_path = (
+        Path(output_info["path"]) if output_info and output_info.get("path") else paths.results_path
+    )
+    report_path = write_html_report(payload, pipeline_results_path.with_suffix(".html"))
     output_fn("")
     output_fn("Run complete")
     output_fn(f"Documents: {payload.get('document_count', 0)}")
@@ -104,6 +110,8 @@ def run_terminal_annotation_ui(
         output_fn(f"{label}: {path}")
     output_fn(f"Config: {paths.config_path}")
     output_fn(f"Manifest: {paths.manifest_path}")
+    output_fn(f"HTML report: {report_path}")
+    output_fn(f"Open {report_path.as_uri()} in your browser to view the annotated results.")
     return payload
 
 

--- a/tests/test_entity_types.py
+++ b/tests/test_entity_types.py
@@ -25,9 +25,9 @@ def test_entity_type_specs_are_the_source_of_truth() -> None:
     }
     assert (
         "bern2",
-        "Drug",
-        "drug",
-        ("DrugBank",),
+        "Cell type",
+        "cell_type",
+        ("Cell Ontology",),
     ) in {
         (spec.annotator, spec.source_entity_type, spec.canonical_entity_type, spec.database_ids)
         for spec in ANNOTATOR_ENTITY_TYPE_SPECS
@@ -39,7 +39,12 @@ def test_normalize_entity_type_uses_explicit_table_rows() -> None:
     assert normalize_entity_type("Gene / protein") == "gene"
     assert normalize_entity_type("Chemical / drug") == "drug"
     assert normalize_entity_type("Mutation / variant") == "variant"
+    assert normalize_entity_type("Mutation") == "variant"
+    assert normalize_entity_type("CellLine") == "cell_line"
     assert normalize_entity_type("Cell line") == "cell_line"
+    assert normalize_entity_type("cell_type") == "cell_type"
+    assert normalize_entity_type("DNA") == "dna"
+    assert normalize_entity_type("RNA") == "rna"
     assert normalize_entity_type("micro_rna") == "micro_rna"
     assert normalize_entity_type("chemical_entity") == "chemical_entity"
 
@@ -52,7 +57,9 @@ def test_annotator_capabilities_include_tasks_and_supported_entity_types() -> No
     assert annotator_supports_nen("bern2") is True
     assert annotator_supports_nen("flair") is False
     assert "variant" in ANNOTATOR_ENTITY_TYPES["bern2"]
-    assert "cell_line" not in ANNOTATOR_ENTITY_TYPES["bern2"]
+    assert {"cell_line", "cell_type", "dna", "rna"} <= ANNOTATOR_ENTITY_TYPES["bern2"]
+    assert "cell_type" not in ANNOTATOR_ENTITY_TYPES["pubtator3"]
+    assert "dna" not in ANNOTATOR_ENTITY_TYPES["flair"]
     assert "mirna" not in ANNOTATOR_ENTITY_TYPES["flair"]
 
 
@@ -72,5 +79,7 @@ def test_normalization_databases_are_source_backed() -> None:
     assert normalization_databases("Chemical / drug", "pubtator3") == ("MeSH",)
     assert normalization_databases("variant", "pubtator3") == ("dbSNP", "ClinGen Allele Registry")
     assert normalization_databases("Drug", "bern2") == ("DrugBank",)
+    assert normalization_databases("cell_type", "bern2") == ("Cell Ontology",)
+    assert normalization_databases("cell_line", "bern2") == ("Cellosaurus",)
     assert normalization_databases("species", "bern2") == ("NCBI Taxonomy",)
     assert normalization_databases("gene", "flair") == ()

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -100,6 +100,21 @@ def test_render_highlighted_text_picks_pubtator_over_bern2_for_overlap() -> None
     assert payload["primary_source"] == "pubtator3"
 
 
+def test_format_canonical_id_normalizes_prefix_and_bare_numbers() -> None:
+    from bio_annotation.report.html_report import _format_canonical_id
+
+    # Prefix casing is unified regardless of the annotator's raw output.
+    assert _format_canonical_id("mesh:D009369") == "MESH:D009369"
+    assert _format_canonical_id("MESH:D007249") == "MESH:D007249"
+    assert _format_canonical_id("ncbigene:10397") == "NCBIGene:10397"
+    # Bare numbers gain the prefix the prefixed annotators use.
+    assert _format_canonical_id("9606", "species") == "NCBITaxon:9606"
+    assert _format_canonical_id("5728", "gene") == "NCBIGene:5728"
+    # Unknown prefixes and empty ids pass through unchanged.
+    assert _format_canonical_id("CVCL:0139") == "CVCL:0139"
+    assert _format_canonical_id("", "gene") == ""
+
+
 def test_render_highlighted_text_handles_nan_confidence() -> None:
     # BERN2 can return a NaN confidence; the popup's data-entity must stay valid
     # JSON (NaN -> null) or the browser's JSON.parse throws and no popup opens.

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from bio_annotation.report.html_report import (
+    build_canonical_text,
+    group_annotations_by_span,
+    render_highlighted_text,
+    write_html_report,
+)
+
+
+def sample_payload() -> dict:
+    return {
+        "document_count": 1,
+        "annotation_summary": {"annotation_count": 3, "keyword_count": 2},
+        "documents": [
+            {
+                "document_id": "PMID:1",
+                "pmid": "1",
+                "title": "PTEN regulates glioblastoma",
+                "abstract": "PTEN and miR-21 in glioblastoma cells.",
+            }
+        ],
+        "annotations": [
+            {
+                "document_id": "PMID:1",
+                "source": "pubtator3",
+                "span_text": "PTEN",
+                "entity_type": "gene",
+                "canonical_id": "5728",
+                "canonical_name": "PTEN",
+                "start": 0,
+                "end": 4,
+                "confidence": None,
+            },
+            {
+                "document_id": "PMID:1",
+                "source": "bern2",
+                "span_text": "PTEN",
+                "entity_type": "gene",
+                "canonical_id": "NCBIGene:5728",
+                "canonical_name": "PTEN",
+                "start": 0,
+                "end": 4,
+                "confidence": 0.97,
+            },
+            {
+                "document_id": "PMID:1",
+                "source": "pubtator3",
+                "span_text": "glioblastoma",
+                "entity_type": "disease",
+                "canonical_id": "MESH:D005909",
+                "canonical_name": "Glioblastoma",
+                "start": 15,
+                "end": 27,
+                "confidence": None,
+            },
+        ],
+    }
+
+
+def test_build_canonical_text_joins_with_single_newline() -> None:
+    text = build_canonical_text({"title": "abc", "abstract": "def"})
+    assert text == "abc\ndef"
+
+
+def test_render_highlighted_text_emits_mark_with_data_attribute() -> None:
+    text = "PTEN and others"
+    annotation = {
+        "source": "pubtator3",
+        "span_text": "PTEN",
+        "entity_type": "gene",
+        "canonical_id": "5728",
+        "canonical_name": "PTEN",
+        "start": 0,
+        "end": 4,
+    }
+    html = render_highlighted_text(text, [annotation])
+    assert '<mark class="entity entity-gene"' in html
+    assert "PTEN" in html
+    assert 'data-entity="' in html
+
+
+def test_render_highlighted_text_picks_pubtator_over_bern2_for_overlap() -> None:
+    text = "PTEN and others"
+    annotations = [
+        {"source": "bern2", "span_text": "PTEN", "entity_type": "gene", "start": 0, "end": 4, "canonical_id": "NCBIGene:5728"},
+        {"source": "pubtator3", "span_text": "PTEN", "entity_type": "gene", "start": 0, "end": 4, "canonical_id": "5728"},
+    ]
+    html = render_highlighted_text(text, annotations)
+    assert html.count("<mark") == 1
+    match = re.search(r'data-entity="([^"]+)"', html)
+    assert match is not None
+    payload = json.loads(match.group(1).replace("&quot;", '"'))
+    assert payload["primary_source"] == "pubtator3"
+
+
+def test_render_highlighted_text_handles_nan_confidence() -> None:
+    # BERN2 can return a NaN confidence; the popup's data-entity must stay valid
+    # JSON (NaN -> null) or the browser's JSON.parse throws and no popup opens.
+    text = "PTEN cells"
+    annotation = {
+        "source": "bern2",
+        "span_text": "PTEN",
+        "entity_type": "gene",
+        "canonical_id": "NCBIGene:5728",
+        "start": 0,
+        "end": 4,
+        "confidence": float("nan"),
+    }
+    rendered = render_highlighted_text(text, [annotation])
+    assert "NaN" not in rendered
+    match = re.search(r'data-entity="([^"]+)"', rendered)
+    assert match is not None
+    payload = json.loads(match.group(1).replace("&quot;", '"'))
+    assert payload["by_source"]["bern2"][0]["confidence"] is None
+
+
+def test_group_annotations_by_span_dedupes_within_source() -> None:
+    annotations = [
+        {"source": "pubtator3", "span_text": "tumor", "entity_type": "disease", "canonical_id": "MESH:D009369", "canonical_name": "Neoplasms", "start": 5, "end": 10},
+        {"source": "pubtator3", "span_text": "tumor", "entity_type": "disease", "canonical_id": "MESH:D009369", "canonical_name": "Neoplasms", "start": 50, "end": 55},
+        {"source": "pubtator3", "span_text": "tumor", "entity_type": "disease", "canonical_id": "MESH:D009369", "canonical_name": "Neoplasms", "start": 100, "end": 105},
+    ]
+    rows = group_annotations_by_span(annotations)
+    assert len(rows) == 1
+    hits = rows[0]["by_source"]["pubtator3"]
+    assert len(hits) == 1
+    assert hits[0]["mentions"] == 3
+
+
+def test_write_html_report_creates_self_contained_file(tmp_path: Path) -> None:
+    output = tmp_path / "results.html"
+    written = write_html_report(sample_payload(), output)
+    assert written == output.resolve()
+    html = output.read_text(encoding="utf-8")
+    assert "<!--CONTENT-->" not in html
+    assert "<style>" in html and "<script>" in html
+    assert "regulates" in html
+    assert "PTEN" in html
+    assert "glioblastoma" in html
+    assert "PubTator3" in html
+    assert "PMID:" in html
+    assert "data-entity=" in html
+
+
+def test_title_is_highlighted_in_h2(tmp_path: Path) -> None:
+    output = tmp_path / "results.html"
+    write_html_report(sample_payload(), output)
+    html = output.read_text(encoding="utf-8")
+    h2_start = html.index("<h2>")
+    h2_end = html.index("</h2>", h2_start)
+    h2 = html[h2_start:h2_end]
+    assert "<mark" in h2
+    assert "PTEN" in h2
+
+
+def test_compute_stats_counts_unique_positions_not_annotations() -> None:
+    from bio_annotation.report.html_report import _compute_stats
+    annotations = [
+        {"source": "pubtator3", "span_text": "Glio", "entity_type": "disease", "start": 0, "end": 4},
+        {"source": "bern2", "span_text": "Glio", "entity_type": "disease", "start": 0, "end": 4},
+        {"source": "flair", "span_text": "Glio", "entity_type": "disease", "start": 0, "end": 4},
+        {"source": "pubtator3", "span_text": "Glio", "entity_type": "disease", "start": 40, "end": 44},
+    ]
+    stats = _compute_stats(annotations)
+    assert stats["disease"] == [("Glio", 2)]
+
+
+def test_stats_panel_renders_per_document_and_run(tmp_path: Path) -> None:
+    output = tmp_path / "results.html"
+    write_html_report(sample_payload(), output)
+    html = output.read_text(encoding="utf-8")
+    assert "stats-run" in html
+    assert "stats-doc" in html
+    assert "Bioconcepts in this run" in html
+    assert "Bioconcepts in this document" in html
+    assert "PTEN" in html and "glioblastoma" in html
+
+
+def test_write_html_report_handles_empty_documents(tmp_path: Path) -> None:
+    output = tmp_path / "empty.html"
+    write_html_report({"documents": [], "annotations": []}, output)
+    html = output.read_text(encoding="utf-8")
+    assert "No documents in this run" in html
+
+
+def test_split_no_title_does_not_shift_offsets() -> None:
+    # Plain-text doc: Document.text has no "title\n\n" prefix, so offsets index
+    # straight into the abstract and must not be rebased.
+    from bio_annotation.report.html_report import _split_annotations_by_region
+
+    ann = [{"start": 3, "end": 8, "entity_type": "gene"}]
+    title_anns, abstract_anns = _split_annotations_by_region(ann, 0)
+    assert title_anns == []
+    assert abstract_anns == [{"start": 3, "end": 8, "entity_type": "gene"}]
+
+
+def test_split_with_title_rebases_abstract_by_two() -> None:
+    # With a title, Document.text is "title\n\nabstract", so the abstract starts
+    # at title_length + 2 and abstract offsets are rebased by that amount.
+    from bio_annotation.report.html_report import _split_annotations_by_region
+
+    ann = [
+        {"start": 0, "end": 3, "entity_type": "gene"},       # title region
+        {"start": 7, "end": 12, "entity_type": "disease"},   # abstract region (5 + 2)
+    ]
+    title_anns, abstract_anns = _split_annotations_by_region(ann, 5)
+    assert title_anns == [{"start": 0, "end": 3, "entity_type": "gene"}]
+    assert abstract_anns == [{"start": 0, "end": 5, "entity_type": "disease"}]

--- a/tests/test_terminal_ui.py
+++ b/tests/test_terminal_ui.py
@@ -19,9 +19,8 @@ def test_parse_pmids_deduplicates_common_separators() -> None:
 
 
 def test_find_unsupported_entity_types_reports_exact_compatibility() -> None:
-    assert find_unsupported_entity_types(["bern2", "flair"], ["variant", "cell_line"]) == {
-        "bern2": ["cell_line"],
-        "flair": ["variant"],
+    assert find_unsupported_entity_types(["bern2", "flair"], ["variant", "cell_line", "cell_type"]) == {
+        "flair": ["variant", "cell_type"],
     }
 
 
@@ -343,5 +342,5 @@ def test_run_terminal_annotation_ui_warns_for_unsupported_entity_types(tmp_path)
     )
 
     assert "Entity type compatibility warning:" in messages
-    assert any("BERN2 does not produce: Cell line" in message for message in messages)
     assert any("Flair / HunFlair does not produce: Variant / mutation" in message for message in messages)
+    assert not any("BERN2 does not produce" in message for message in messages)


### PR DESCRIPTION
## Summary

  - Added BERN2 support for cell_line, cell_type, dna, and rna.
  - Kept variant as the universal canonical label for mutations.
  - Added explicit normalization aliases for labels like Mutation, CellLine, cell_type, DNA, and RNA.
  - Updated terminal UI compatibility tests so BERN2 no longer warns for cell_line.
  - Updated README and workflow docs to list the expanded canonical entity types and use variant in config examples.

 ## Validation

  - git diff --check passed

  - tests/test_entity_types.py
  - tests/test_terminal_ui.py
  - README.md
  - docs/workflow-spec.md