### PR TITLE
Stanza i2b2 clinical NER 

### DIFF
--- a/src/bio_annotation/entity_proposal/stanza_proposer.py
+++ b/src/bio_annotation/entity_proposal/stanza_proposer.py
@@ -7,8 +7,19 @@ from bio_annotation.entity_proposal._shared import make_annotation
 from bio_annotation.schemas.document import Document
 from bio_annotation.schemas.entity import Annotation
 
-STANZA_MODELS: tuple[str, ...] = ("bc5cdr", "bionlp13cg", "jnlpba")
+STANZA_MODELS: tuple[str, ...] = ("bc5cdr", "bionlp13cg", "jnlpba", "i2b2")
 DEFAULT_STANZA_PACKAGE = "craft"
+
+# Clinical Stanza models are tokenized with the MIMIC package rather than the
+# CRAFT biomedical tokenizer. Models absent here fall back to
+# DEFAULT_STANZA_PACKAGE; an explicit config package still overrides both.
+STANZA_MODEL_PACKAGES: dict[str, str] = {
+    "i2b2": "mimic",
+}
+
+
+def default_package_for_model(model: str) -> str:
+    return STANZA_MODEL_PACKAGES.get(model, DEFAULT_STANZA_PACKAGE)
 
 STANZA_INSTALL_HINT = (
     "The Stanza annotators require the optional Stanza dependency. "
@@ -26,6 +37,35 @@ def stanza_model_for_annotator(annotator: str) -> str:
 
 STANZA_ANNOTATORS: tuple[str, ...] = tuple(stanza_source(model) for model in STANZA_MODELS)
 
+# Clinical Stanza models (i2b2, radiology) often tag a noun phrase together with
+# its leading determiner on out-of-domain text (e.g. "a stop codon", "This
+# protein"). Strip the determiner and keep character offsets aligned. Ordered so
+# longer determiners match before shorter ones.
+_LEADING_DETERMINERS = ("these", "those", "this", "the", "an", "a")
+_DETERMINER_WORDS = frozenset(_LEADING_DETERMINERS)
+
+
+def _strip_leading_determiner(
+    text: str, start: int | None, end: int | None
+) -> tuple[str, int | None, int | None]:
+    lowered = text.lower()
+    for determiner in _LEADING_DETERMINERS:
+        if lowered.startswith(determiner + " "):
+            removed = len(text) - len(text[len(determiner):].lstrip())
+            trimmed = text[removed:]
+            if isinstance(start, int):
+                return trimmed, start + removed, end
+            return trimmed, start, end
+    return text, start, end
+
+
+def _is_noise_span(text: str) -> bool:
+    """True for out-of-domain junk: a bare determiner or lone punctuation like "-"."""
+    core = text.strip("-/ \t")
+    if len(core) < 2 or not any(ch.isalnum() for ch in core):
+        return True
+    return text.strip().lower() in _DETERMINER_WORDS
+
 
 def parse_stanza_entities(
     document: Document,
@@ -38,14 +78,19 @@ def parse_stanza_entities(
         text = getattr(entity, "text", None)
         if not text:
             continue
+        start = getattr(entity, "start_char", None)
+        end = getattr(entity, "end_char", None)
+        text, start, end = _strip_leading_determiner(text, start, end)
+        if not text or _is_noise_span(text):
+            continue
         annotations.append(
             make_annotation(
                 document=document,
                 source=source,
                 span_text=text,
                 entity_type=getattr(entity, "type", None),
-                start=getattr(entity, "start_char", None),
-                end=getattr(entity, "end_char", None),
+                start=start,
+                end=end,
             )
         )
     return annotations
@@ -82,7 +127,7 @@ def annotate_with_stanza(
 
     if pipeline is None:
         loader = pipeline_loader or _load_stanza_pipeline
-        pipeline = loader(package or DEFAULT_STANZA_PACKAGE, model)
+        pipeline = loader(package or default_package_for_model(model), model)
 
     parsed = pipeline(document.text)
     return parse_stanza_entities(document, getattr(parsed, "ents", []) or [], source=source)

--- a/src/bio_annotation/entity_types.py
+++ b/src/bio_annotation/entity_types.py
@@ -113,6 +113,11 @@ STANZA_ENTITY_TYPE_SPECS: tuple[tuple[str, str, str, str], ...] = (
     ("stanza_jnlpba", "Stanza JNLPBA", "RNA", "rna"),
     ("stanza_jnlpba", "Stanza JNLPBA", "Cell line", "cell_line"),
     ("stanza_jnlpba", "Stanza JNLPBA", "Cell type", "cell_type"),
+    # Stanza i2b2 is a clinical model (2010 i2b2/VA) emitting problem / test /
+    # treatment, the same clinical categories ClinicalBERT uses.
+    ("stanza_i2b2", "Stanza i2b2", "Problem", "problem"),
+    ("stanza_i2b2", "Stanza i2b2", "Test", "test"),
+    ("stanza_i2b2", "Stanza i2b2", "Treatment", "treatment"),
 )
 
 
@@ -436,6 +441,24 @@ ANNOTATOR_CAPABILITIES: dict[str, AnnotatorCapability] = {
             spec.canonical_entity_type: spec.database_ids
             for spec in ANNOTATOR_ENTITY_TYPE_SPECS
             if spec.annotator == "stanza_jnlpba"
+        },
+        normalization_fields=(),
+    ),
+    "stanza_i2b2": AnnotatorCapability(
+        label="Stanza i2b2",
+        tasks=("NER",),
+        entity_types=tuple(
+            dict.fromkeys(
+                spec.canonical_entity_type
+                for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+                if spec.annotator == "stanza_i2b2"
+            )
+        ),
+        normalization_status="not_returned",
+        normalization_databases={
+            spec.canonical_entity_type: spec.database_ids
+            for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+            if spec.annotator == "stanza_i2b2"
         },
         normalization_fields=(),
     ),

--- a/tests/test_annotators.py
+++ b/tests/test_annotators.py
@@ -933,6 +933,53 @@ def test_stanza_jnlpba_loads_fixed_model_and_keeps_cell_type_distinct() -> None:
     ]
 
 
+def test_stanza_i2b2_maps_clinical_types_and_stamps_source() -> None:
+    document = sample_document()
+    entities = [
+        FakeStanzaEntity("glioblastoma", "PROBLEM", 15, 27),
+        FakeStanzaEntity("MRI", "TEST", 0, 3),
+        FakeStanzaEntity("cisplatin", "TREATMENT", 40, 49),
+    ]
+
+    annotations = annotate_with_stanza(document, "i2b2", entities=entities)
+
+    assert [a.entity_type for a in annotations] == ["problem", "test", "treatment"]
+    assert all(a.source == "stanza_i2b2" for a in annotations)
+
+
+def test_stanza_i2b2_defaults_to_mimic_tokenizer_package() -> None:
+    from bio_annotation.entity_proposal.stanza_proposer import default_package_for_model
+
+    loaded: list[tuple[str, str]] = []
+
+    def fake_loader(package: str, model: str):
+        loaded.append((package, model))
+        return lambda text: FakeStanzaDoc([])
+
+    annotate_with_stanza(sample_document(), "i2b2", pipeline_loader=fake_loader)
+
+    # i2b2 is clinical, so it must default to the MIMIC tokenizer, not CRAFT.
+    assert loaded == [("mimic", "i2b2")]
+    assert default_package_for_model("i2b2") == "mimic"
+    assert default_package_for_model("bc5cdr") == "craft"
+
+
+def test_stanza_i2b2_trims_leading_determiners_and_drops_noise() -> None:
+    document = sample_document()
+    entities = [
+        FakeStanzaEntity("a stop codon", "TREATMENT", 0, 12),
+        FakeStanzaEntity("This protein", "TEST", 13, 25),
+        FakeStanzaEntity("the breast and ovarian cancer", "PROBLEM", 26, 55),
+        FakeStanzaEntity("a", "PROBLEM", 56, 57),
+        FakeStanzaEntity("-", "PROBLEM", 58, 59),
+    ]
+
+    annotations = annotate_with_stanza(document, "i2b2", entities=entities)
+
+    spans = [a.span_text for a in annotations]
+    assert spans == ["stop codon", "protein", "breast and ovarian cancer"]
+
+
 def test_run_all_annotators_returns_consistent_result_map() -> None:
     document = sample_document()
     results = run_all_annotators(


### PR DESCRIPTION
Registers the Stanza i2b2 clinical model (2010 i2b2/VA) as a new annotator `stanza_i2b2`, emitting problem / test / treatment (reusing the same canonical types as ClinicalBERT).

- Adds "i2b2" to STANZA_MODELS plus entity specs and an AnnotatorCapability
- Defaults i2b2 to the MIMIC tokenizer package (clinical), not CRAFT (an explicit config package still overrides)
- Cleans up out-of-domain spans in parse_stanza_entities: strips a leading determiner (a/an/the/this/these/those) and drops bare-determiner or punctuation-only noise. 
- Tests for the mapping, the MIMIC default, and the span cleanup

**Note**: the determiner/noise cleanup duplicates the ClinicalBERT helper; worth pulling into a shared function in a follow-up.
