### PR TITLE
Add Stanza radiology clinical NER model 

### DIFF
--- a/src/bio_annotation/entity_proposal/stanza_proposer.py
+++ b/src/bio_annotation/entity_proposal/stanza_proposer.py
@@ -7,8 +7,19 @@ from bio_annotation.entity_proposal._shared import make_annotation
 from bio_annotation.schemas.document import Document
 from bio_annotation.schemas.entity import Annotation
 
-STANZA_MODELS: tuple[str, ...] = ("bc5cdr", "bionlp13cg", "jnlpba")
+STANZA_MODELS: tuple[str, ...] = ("bc5cdr", "bionlp13cg", "jnlpba", "radiology")
 DEFAULT_STANZA_PACKAGE = "craft"
+
+# Clinical Stanza models are tokenized with the MIMIC package rather than the
+# CRAFT biomedical tokenizer. Models absent here fall back to
+# DEFAULT_STANZA_PACKAGE; an explicit config package still overrides both.
+STANZA_MODEL_PACKAGES: dict[str, str] = {
+    "radiology": "mimic",
+}
+
+
+def default_package_for_model(model: str) -> str:
+    return STANZA_MODEL_PACKAGES.get(model, DEFAULT_STANZA_PACKAGE)
 
 STANZA_INSTALL_HINT = (
     "The Stanza annotators require the optional Stanza dependency. "
@@ -26,6 +37,35 @@ def stanza_model_for_annotator(annotator: str) -> str:
 
 STANZA_ANNOTATORS: tuple[str, ...] = tuple(stanza_source(model) for model in STANZA_MODELS)
 
+# Clinical Stanza models (radiology, i2b2) often tag a noun phrase together with
+# its leading determiner on out-of-domain text (e.g. "the large mass"). Strip the
+# determiner and keep character offsets aligned. Ordered so longer determiners
+# match before shorter ones.
+_LEADING_DETERMINERS = ("these", "those", "this", "the", "an", "a")
+_DETERMINER_WORDS = frozenset(_LEADING_DETERMINERS)
+
+
+def _strip_leading_determiner(
+    text: str, start: int | None, end: int | None
+) -> tuple[str, int | None, int | None]:
+    lowered = text.lower()
+    for determiner in _LEADING_DETERMINERS:
+        if lowered.startswith(determiner + " "):
+            removed = len(text) - len(text[len(determiner):].lstrip())
+            trimmed = text[removed:]
+            if isinstance(start, int):
+                return trimmed, start + removed, end
+            return trimmed, start, end
+    return text, start, end
+
+
+def _is_noise_span(text: str) -> bool:
+    """True for out-of-domain junk: a bare determiner or lone punctuation like "-"."""
+    core = text.strip("-/ \t")
+    if len(core) < 2 or not any(ch.isalnum() for ch in core):
+        return True
+    return text.strip().lower() in _DETERMINER_WORDS
+
 
 def parse_stanza_entities(
     document: Document,
@@ -38,14 +78,19 @@ def parse_stanza_entities(
         text = getattr(entity, "text", None)
         if not text:
             continue
+        start = getattr(entity, "start_char", None)
+        end = getattr(entity, "end_char", None)
+        text, start, end = _strip_leading_determiner(text, start, end)
+        if not text or _is_noise_span(text):
+            continue
         annotations.append(
             make_annotation(
                 document=document,
                 source=source,
                 span_text=text,
                 entity_type=getattr(entity, "type", None),
-                start=getattr(entity, "start_char", None),
-                end=getattr(entity, "end_char", None),
+                start=start,
+                end=end,
             )
         )
     return annotations
@@ -82,7 +127,7 @@ def annotate_with_stanza(
 
     if pipeline is None:
         loader = pipeline_loader or _load_stanza_pipeline
-        pipeline = loader(package or DEFAULT_STANZA_PACKAGE, model)
+        pipeline = loader(package or default_package_for_model(model), model)
 
     parsed = pipeline(document.text)
     return parse_stanza_entities(document, getattr(parsed, "ents", []) or [], source=source)

--- a/src/bio_annotation/entity_types.py
+++ b/src/bio_annotation/entity_types.py
@@ -113,6 +113,14 @@ STANZA_ENTITY_TYPE_SPECS: tuple[tuple[str, str, str, str], ...] = (
     ("stanza_jnlpba", "Stanza JNLPBA", "RNA", "rna"),
     ("stanza_jnlpba", "Stanza JNLPBA", "Cell line", "cell_line"),
     ("stanza_jnlpba", "Stanza JNLPBA", "Cell type", "cell_type"),
+    # Stanza radiology is a clinical model (Stanford radiology reports) emitting
+    # anatomy / observation / their modifiers / uncertainty. These radiology
+    # categories have no biomedical equivalent, so they are kept as their own types.
+    ("stanza_radiology", "Stanza radiology", "Anatomy", "anatomy"),
+    ("stanza_radiology", "Stanza radiology", "Anatomy modifier", "anatomy_modifier"),
+    ("stanza_radiology", "Stanza radiology", "Observation", "observation"),
+    ("stanza_radiology", "Stanza radiology", "Observation modifier", "observation_modifier"),
+    ("stanza_radiology", "Stanza radiology", "Uncertainty", "uncertainty"),
 )
 
 
@@ -436,6 +444,24 @@ ANNOTATOR_CAPABILITIES: dict[str, AnnotatorCapability] = {
             spec.canonical_entity_type: spec.database_ids
             for spec in ANNOTATOR_ENTITY_TYPE_SPECS
             if spec.annotator == "stanza_jnlpba"
+        },
+        normalization_fields=(),
+    ),
+    "stanza_radiology": AnnotatorCapability(
+        label="Stanza radiology",
+        tasks=("NER",),
+        entity_types=tuple(
+            dict.fromkeys(
+                spec.canonical_entity_type
+                for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+                if spec.annotator == "stanza_radiology"
+            )
+        ),
+        normalization_status="not_returned",
+        normalization_databases={
+            spec.canonical_entity_type: spec.database_ids
+            for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+            if spec.annotator == "stanza_radiology"
         },
         normalization_fields=(),
     ),

--- a/tests/test_annotators.py
+++ b/tests/test_annotators.py
@@ -933,6 +933,59 @@ def test_stanza_jnlpba_loads_fixed_model_and_keeps_cell_type_distinct() -> None:
     ]
 
 
+def test_stanza_radiology_maps_clinical_types_and_stamps_source() -> None:
+    document = sample_document()
+    entities = [
+        FakeStanzaEntity("liver", "ANATOMY", 0, 5),
+        FakeStanzaEntity("right", "ANATOMY_MODIFIER", 6, 11),
+        FakeStanzaEntity("mass", "OBSERVATION", 12, 16),
+        FakeStanzaEntity("large", "OBSERVATION_MODIFIER", 17, 22),
+        FakeStanzaEntity("possible", "UNCERTAINTY", 23, 31),
+    ]
+
+    annotations = annotate_with_stanza(document, "radiology", entities=entities)
+
+    assert [a.entity_type for a in annotations] == [
+        "anatomy",
+        "anatomy_modifier",
+        "observation",
+        "observation_modifier",
+        "uncertainty",
+    ]
+    assert all(a.source == "stanza_radiology" for a in annotations)
+
+
+def test_stanza_radiology_defaults_to_mimic_tokenizer_package() -> None:
+    from bio_annotation.entity_proposal.stanza_proposer import default_package_for_model
+
+    loaded: list[tuple[str, str]] = []
+
+    def fake_loader(package: str, model: str):
+        loaded.append((package, model))
+        return lambda text: FakeStanzaDoc([])
+
+    annotate_with_stanza(sample_document(), "radiology", pipeline_loader=fake_loader)
+
+    # radiology is clinical, so it must default to the MIMIC tokenizer, not CRAFT.
+    assert loaded == [("mimic", "radiology")]
+    assert default_package_for_model("radiology") == "mimic"
+    assert default_package_for_model("bc5cdr") == "craft"
+
+
+def test_stanza_radiology_trims_leading_determiners_and_drops_noise() -> None:
+    document = sample_document()
+    entities = [
+        FakeStanzaEntity("the large mass", "OBSERVATION", 0, 14),
+        FakeStanzaEntity("a", "OBSERVATION", 15, 16),
+        FakeStanzaEntity("-", "ANATOMY", 17, 18),
+        FakeStanzaEntity("liver", "ANATOMY", 19, 24),
+    ]
+
+    annotations = annotate_with_stanza(document, "radiology", entities=entities)
+
+    assert [a.span_text for a in annotations] == ["large mass", "liver"]
+
+
 def test_run_all_annotators_returns_consistent_result_map() -> None:
     document = sample_document()
     results = run_all_annotators(


### PR DESCRIPTION
# Summary
Adds the Stanza radiology model as annotator `stanza_radiology`. Trained on Stanford radiology reports, it tags anatomy / anatomy_modifier / observation /observation_modifier / uncertainty (kept as their own types).

- "radiology" added to STANZA_MODELS; defaults to the MIMIC clinical tokenizer
- Entity specs + capability for the 5 types
- Determiner/noise span cleanup in parse_stanza_entities so it stays clean on out-of-domain (PubMed) text

Note: shares the package-map + cleanup helpers with the i2b2 branch
