### PR TITLE
Add Stanza AnatEM biomedical anatomy NER model

### DIFF
--- a/src/bio_annotation/entity_proposal/stanza_proposer.py
+++ b/src/bio_annotation/entity_proposal/stanza_proposer.py
@@ -7,7 +7,7 @@ from bio_annotation.entity_proposal._shared import make_annotation
 from bio_annotation.schemas.document import Document
 from bio_annotation.schemas.entity import Annotation
 
-STANZA_MODELS: tuple[str, ...] = ("bc5cdr", "bionlp13cg", "jnlpba")
+STANZA_MODELS: tuple[str, ...] = ("bc5cdr", "bionlp13cg", "jnlpba", "anatem")
 DEFAULT_STANZA_PACKAGE = "craft"
 
 STANZA_INSTALL_HINT = (

--- a/src/bio_annotation/entity_types.py
+++ b/src/bio_annotation/entity_types.py
@@ -113,6 +113,9 @@ STANZA_ENTITY_TYPE_SPECS: tuple[tuple[str, str, str, str], ...] = (
     ("stanza_jnlpba", "Stanza JNLPBA", "RNA", "rna"),
     ("stanza_jnlpba", "Stanza JNLPBA", "Cell line", "cell_line"),
     ("stanza_jnlpba", "Stanza JNLPBA", "Cell type", "cell_type"),
+    # Stanza AnatEM is a biomedical model (Anatomical Entity Mention corpus) with a
+    # single anatomical entity type; it uses the default CRAFT biomedical tokenizer.
+    ("stanza_anatem", "Stanza AnatEM", "Anatomy", "anatomy"),
 )
 
 
@@ -436,6 +439,24 @@ ANNOTATOR_CAPABILITIES: dict[str, AnnotatorCapability] = {
             spec.canonical_entity_type: spec.database_ids
             for spec in ANNOTATOR_ENTITY_TYPE_SPECS
             if spec.annotator == "stanza_jnlpba"
+        },
+        normalization_fields=(),
+    ),
+    "stanza_anatem": AnnotatorCapability(
+        label="Stanza AnatEM",
+        tasks=("NER",),
+        entity_types=tuple(
+            dict.fromkeys(
+                spec.canonical_entity_type
+                for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+                if spec.annotator == "stanza_anatem"
+            )
+        ),
+        normalization_status="not_returned",
+        normalization_databases={
+            spec.canonical_entity_type: spec.database_ids
+            for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+            if spec.annotator == "stanza_anatem"
         },
         normalization_fields=(),
     ),

--- a/tests/test_annotators.py
+++ b/tests/test_annotators.py
@@ -933,6 +933,32 @@ def test_stanza_jnlpba_loads_fixed_model_and_keeps_cell_type_distinct() -> None:
     ]
 
 
+def test_stanza_anatem_maps_anatomy_and_stamps_source() -> None:
+    document = sample_document()
+    entities = [
+        FakeStanzaEntity("liver", "ANATOMY", 0, 5),
+        FakeStanzaEntity("lymph nodes", "ANATOMY", 6, 17),
+    ]
+
+    annotations = annotate_with_stanza(document, "anatem", entities=entities)
+
+    assert [a.entity_type for a in annotations] == ["anatomy", "anatomy"]
+    assert all(a.source == "stanza_anatem" for a in annotations)
+
+
+def test_stanza_anatem_uses_craft_biomedical_tokenizer_package() -> None:
+    loaded: list[tuple[str, str]] = []
+
+    def fake_loader(package: str, model: str):
+        loaded.append((package, model))
+        return lambda text: FakeStanzaDoc([])
+
+    annotate_with_stanza(sample_document(), "anatem", pipeline_loader=fake_loader)
+
+    # AnatEM is biomedical, so it uses the default CRAFT tokenizer (not MIMIC).
+    assert loaded == [("craft", "anatem")]
+
+
 def test_run_all_annotators_returns_consistent_result_map() -> None:
     document = sample_document()
     results = run_all_annotators(


### PR DESCRIPTION
# Summary

Adds the Stanza AnatEM model as annotator `stanza_anatem`. Trained on the Anatomical Entity Mention corpus(to be added in benchmarks), it tags a single "anatomy" entity type. Being biomedical, it uses the default `craft tokenizer`, no package handling is needed (unlike the clinical i2b2/radiology models).

- "anatem" added to STANZA_MODELS
- One entity spec (Anatomy -> anatomy) + capability

