### PR TITLE
Biobert

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,12 @@ clinicalbert = [
     "transformers>=4.30,<5",
     "torch>=2.0",
 ]
+biobert = [
+    # BioBERT NER runs as three HuggingFace transformers token-classification
+    # checkpoints (gene / disease / chemical); needs transformers + a torch backend.
+    "transformers>=4.30,<5",
+    "torch>=2.0",
+]
 apollo = [
     # Clinical-AI-Apollo/Medical-NER is a HuggingFace transformers token-
     # classification model; it needs transformers + a torch backend to run locally.
@@ -47,7 +53,7 @@ benchmarks = [
     "tabulate>=0.9",
 ]
 all = [
-    "totalannotator[flair,clinicalbert,apollo,d4data,stanza,benchmarks]",
+    "totalannotator[flair,clinicalbert,biobert,apollo,d4data,stanza,benchmarks]",
 ]
 
 [project.scripts]

--- a/src/bio_annotation/annotators/__init__.py
+++ b/src/bio_annotation/annotators/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 from bio_annotation.annotators.aioner import annotate_with_aioner
 from bio_annotation.annotators.apollo import annotate_with_apollo
 from bio_annotation.annotators.bern2 import annotate_with_bern2
+from bio_annotation.annotators.biobert import annotate_with_biobert
 from bio_annotation.annotators.clinicalbert import annotate_with_clinicalbert
 from bio_annotation.annotators.d4data import annotate_with_d4data
 from bio_annotation.annotators.flair import annotate_with_flair
@@ -38,6 +39,9 @@ def run_all_annotators(
     clinicalbert_response: Any = None,
     clinicalbert_request_fn: Any = None,
     clinicalbert_pipeline: Any = None,
+    biobert_response: Any = None,
+    biobert_request_fn: Any = None,
+    biobert_pipelines: Any = None,
     apollo_response: Any = None,
     apollo_request_fn: Any = None,
     apollo_pipeline: Any = None,
@@ -91,6 +95,20 @@ def run_all_annotators(
             request_fn=clinicalbert_request_fn,
             pipeline=clinicalbert_pipeline,
         )
+    # BioBERT loads local HuggingFace models (one per entity family), so only
+    # invoke it when an explicit response, request function, or loaded pipelines
+    # are supplied.
+    if (
+        biobert_response is not None
+        or biobert_request_fn is not None
+        or biobert_pipelines is not None
+    ):
+        results["biobert"] = annotate_with_biobert(
+            document,
+            response=biobert_response,
+            request_fn=biobert_request_fn,
+            pipelines=biobert_pipelines,
+        )
     # apollo loads a local HuggingFace model, so only invoke it when an explicit
     # response, request function, or loaded pipeline is supplied (avoids loading
     # the model in callers that don't use it, e.g. the demo command).
@@ -143,7 +161,7 @@ def run_all_annotators(
 
 def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation]:
     annotations: list[Annotation] = []
-    for source in ("bern2", "flair", "pubtator3", "aioner", "clinicalbert", "apollo", "d4data", "medcat", *STANZA_ANNOTATORS):
+    for source in ("bern2", "flair", "pubtator3", "aioner", "clinicalbert", "biobert", "apollo", "d4data", "medcat", *STANZA_ANNOTATORS):
         annotations.extend(results.get(source, []))
     return annotations
 
@@ -151,6 +169,7 @@ __all__ = [
     "annotate_with_aioner",
     "annotate_with_apollo",
     "annotate_with_bern2",
+    "annotate_with_biobert",
     "annotate_with_clinicalbert",
     "annotate_with_d4data",
     "annotate_with_flair",

--- a/src/bio_annotation/annotators/biobert.py
+++ b/src/bio_annotation/annotators/biobert.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from bio_annotation.entity_proposal.biobert_proposer import (
+    BIOBERT_INSTALL_HINT,
+    DEFAULT_BIOBERT_MODELS,
+    _load_biobert_pipeline,
+    annotate_with_biobert,
+    load_biobert_pipelines,
+    parse_biobert_response,
+)
+
+__all__ = [
+    "BIOBERT_INSTALL_HINT",
+    "DEFAULT_BIOBERT_MODELS",
+    "_load_biobert_pipeline",
+    "annotate_with_biobert",
+    "load_biobert_pipelines",
+    "parse_biobert_response",
+]

--- a/src/bio_annotation/entity_proposal/__init__.py
+++ b/src/bio_annotation/entity_proposal/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from bio_annotation.entity_proposal.apollo_proposer import annotate_with_apollo
 from bio_annotation.entity_proposal.bern2_proposer import annotate_with_bern2
+from bio_annotation.entity_proposal.biobert_proposer import annotate_with_biobert
 from bio_annotation.entity_proposal.clinicalbert_proposer import annotate_with_clinicalbert
 from bio_annotation.entity_proposal.d4data_proposer import annotate_with_d4data
 from bio_annotation.entity_proposal.flair_proposer import annotate_with_flair
@@ -46,6 +47,9 @@ def run_all_annotators(
     clinicalbert_response: Any = None,
     clinicalbert_request_fn: Any = None,
     clinicalbert_pipeline: Any = None,
+    biobert_response: Any = None,
+    biobert_request_fn: Any = None,
+    biobert_pipelines: Any = None,
     apollo_response: Any = None,
     apollo_request_fn: Any = None,
     apollo_pipeline: Any = None,
@@ -98,6 +102,18 @@ def run_all_annotators(
             request_fn=clinicalbert_request_fn,
             pipeline=clinicalbert_pipeline,
         )
+    # Only invoke BioBERT when a response, request function, or pipelines are provided.
+    if (
+        biobert_response is not None
+        or biobert_request_fn is not None
+        or biobert_pipelines is not None
+    ):
+        results["biobert"] = annotate_with_biobert(
+            document,
+            response=biobert_response,
+            request_fn=biobert_request_fn,
+            pipelines=biobert_pipelines,
+        )
     # Only invoke apollo when a response, request function, or pipeline is provided.
     if (
         apollo_response is not None
@@ -143,7 +159,7 @@ def run_all_annotators(
 
 def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation]:
     annotations: list[Annotation] = []
-    for source in ("bern2", "flair", "pubtator3", "aioner", "clinicalbert", "apollo", "d4data", "medcat", *STANZA_ANNOTATORS):
+    for source in ("bern2", "flair", "pubtator3", "aioner", "clinicalbert", "biobert", "apollo", "d4data", "medcat", *STANZA_ANNOTATORS):
         annotations.extend(results.get(source, []))
     return annotations
 
@@ -152,6 +168,7 @@ __all__ = [
     "annotate_with_aioner",
     "annotate_with_apollo",
     "annotate_with_bern2",
+    "annotate_with_biobert",
     "annotate_with_clinicalbert",
     "annotate_with_d4data",
     "annotate_with_flair",

--- a/src/bio_annotation/entity_proposal/biobert_proposer.py
+++ b/src/bio_annotation/entity_proposal/biobert_proposer.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any, Callable, Iterable
+
+from bio_annotation.entity_proposal._shared import make_annotation
+from bio_annotation.schemas.document import Document
+from bio_annotation.schemas.entity import Annotation
+
+# BioBERT NER is published as per-entity fine-tuned checkpoints rather than a
+# single multi-type model. The biobert annotator runs one HuggingFace token-
+# classification model per canonical type and merges them, so a single "biobert"
+# source covers gene / disease / chemical. Each checkpoint recognises one family,
+# so the producing model decides the entity type (the raw span label is ignored).
+DEFAULT_BIOBERT_MODELS: dict[str, str] = {
+    "gene": "alvaroalon2/biobert_genetic_ner",
+    "disease": "alvaroalon2/biobert_diseases_ner",
+    "drug": "alvaroalon2/biobert_chemical_ner",
+}
+
+BIOBERT_INSTALL_HINT = (
+    "The BioBERT annotator requires the optional Hugging Face dependencies. "
+    "Install them with: uv sync --extra biobert"
+)
+
+# Trim leading/trailing punctuation off spans while keeping offsets correct.
+# Hyphen and slash are excluded since they occur inside biomedical terms
+# (e.g. "5-HT", "mg/dL", "IL-2").
+_BOUNDARY_CHARS = " \t\n\r\f\v.,;:!?()[]{}\"'"
+
+
+def _trim_boundary(
+    text: str, start: int | None, end: int | None
+) -> tuple[str, int | None, int | None]:
+    inner = text.strip(_BOUNDARY_CHARS)
+    if not inner or not isinstance(start, int) or not isinstance(end, int):
+        return inner, start, end
+    lead = len(text) - len(text.lstrip(_BOUNDARY_CHARS))
+    new_start = start + lead
+    return inner, new_start, new_start + len(inner)
+
+
+def parse_biobert_response(
+    document: Document,
+    payload: Iterable[Any] | None,
+    *,
+    entity_type: str,
+) -> list[Annotation]:
+    """Parse one BioBERT checkpoint's HuggingFace token-classification output.
+
+    Every returned span is stamped with ``entity_type`` because each checkpoint
+    recognises a single entity family. The pipeline uses
+    ``aggregation_strategy="first"``, so spans are already word-grouped.
+    """
+
+    if not payload:
+        return []
+
+    annotations: list[Annotation] = []
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        start = item.get("start")
+        end = item.get("end")
+        if isinstance(start, int) and isinstance(end, int) and 0 <= start < end:
+            span_text = document.text[start:end]
+        else:
+            span_text = item.get("word")
+            start = end = None
+        if not span_text:
+            continue
+        span_text, start, end = _trim_boundary(span_text, start, end)
+        # Drop pure-punctuation spans, but keep short gene names (e.g. "p53").
+        if not span_text or not any(ch.isalnum() for ch in span_text):
+            continue
+
+        annotations.append(
+            make_annotation(
+                document=document,
+                source="biobert",
+                span_text=span_text,
+                entity_type=entity_type,
+                start=start,
+                end=end,
+                confidence=item.get("score"),
+            )
+        )
+
+    return annotations
+
+
+@lru_cache(maxsize=8)
+def _load_biobert_pipeline(model: str) -> Any:
+    try:
+        from transformers import pipeline
+    except ImportError as exc:
+        raise RuntimeError(BIOBERT_INSTALL_HINT) from exc
+
+    # "first" groups sub-word tokens into whole words and keeps the first
+    # sub-word's label, matching these B-/I- tagging checkpoints.
+    return pipeline(
+        "ner",
+        model=model,
+        tokenizer=model,
+        aggregation_strategy="first",
+    )
+
+
+def load_biobert_pipelines(
+    models: dict[str, str] | None = None,
+    *,
+    pipeline_loader: Callable[[str], Any] | None = None,
+) -> dict[str, Any]:
+    """Load one pipeline per entity family, so a run reuses them across documents."""
+    models = models or DEFAULT_BIOBERT_MODELS
+    loader = pipeline_loader or _load_biobert_pipeline
+    return {entity_type: loader(model) for entity_type, model in models.items()}
+
+
+def annotate_with_biobert(
+    document: Document,
+    *,
+    response: dict[str, Any] | None = None,
+    request_fn: Callable[[Document], dict[str, Any]] | None = None,
+    pipelines: dict[str, Any] | None = None,
+    models: dict[str, str] | None = None,
+    pipeline_loader: Callable[[str], Any] | None = None,
+) -> list[Annotation]:
+    """Run each BioBERT checkpoint and merge into one ``biobert`` result set.
+
+    ``response`` / ``request_fn`` supply pre-computed output as a mapping of
+    entity type -> HuggingFace payload; ``pipelines`` supplies preloaded
+    pipelines keyed the same way.
+    """
+    models = models or DEFAULT_BIOBERT_MODELS
+
+    payloads = response
+    if payloads is None and request_fn is not None:
+        payloads = request_fn(document)
+
+    annotations: list[Annotation] = []
+    if payloads is not None:
+        for entity_type, payload in payloads.items():
+            annotations.extend(
+                parse_biobert_response(document, payload, entity_type=entity_type)
+            )
+        return annotations
+
+    loader = pipeline_loader or _load_biobert_pipeline
+    for entity_type, model in models.items():
+        pipe = pipelines.get(entity_type) if pipelines else None
+        if pipe is None:
+            pipe = loader(model)
+        payload = pipe(document.text)
+        annotations.extend(
+            parse_biobert_response(document, payload, entity_type=entity_type)
+        )
+    return annotations

--- a/src/bio_annotation/entity_proposal/biobert_proposer.py
+++ b/src/bio_annotation/entity_proposal/biobert_proposer.py
@@ -11,12 +11,18 @@ from bio_annotation.schemas.entity import Annotation
 # single multi-type model. The biobert annotator runs one HuggingFace token-
 # classification model per canonical type and merges them, so a single "biobert"
 # source covers gene / disease / chemical. Each checkpoint recognises one family,
-# so the producing model decides the entity type (the raw span label is ignored).
+# so the producing model decides the entity type; the raw label is read only to
+# drop the model's non-entity ("outside") tokens.
 DEFAULT_BIOBERT_MODELS: dict[str, str] = {
     "gene": "alvaroalon2/biobert_genetic_ner",
     "disease": "alvaroalon2/biobert_diseases_ner",
     "drug": "alvaroalon2/biobert_chemical_ner",
 }
+
+# The "outside" (non-entity) tag varies across checkpoints. The diseases model
+# mislabels it as "0" instead of the standard "O", so the transformers pipeline
+# surfaces bogus "0" spans covering plain text. Treat both as outside and drop.
+_OUTSIDE_LABELS = {"O", "0", ""}
 
 BIOBERT_INSTALL_HINT = (
     "The BioBERT annotator requires the optional Hugging Face dependencies. "
@@ -59,6 +65,11 @@ def parse_biobert_response(
     annotations: list[Annotation] = []
     for item in payload:
         if not isinstance(item, dict):
+            continue
+        # The producing model sets the type; the label is only used to skip the
+        # model's "outside" tokens (some checkpoints emit "0" instead of "O").
+        label = item.get("entity_group") or item.get("entity")
+        if label is not None and str(label).strip().upper() in _OUTSIDE_LABELS:
             continue
         start = item.get("start")
         end = item.get("end")

--- a/src/bio_annotation/entity_types.py
+++ b/src/bio_annotation/entity_types.py
@@ -149,6 +149,11 @@ ANNOTATOR_ENTITY_TYPE_SPECS: tuple[AnnotatorEntityTypeSpec, ...] = (
     AnnotatorEntityTypeSpec("aioner", "AIONER", "Species", "species", ()),
     AnnotatorEntityTypeSpec("aioner", "AIONER", "Variant", "variant", ()),
     AnnotatorEntityTypeSpec("aioner", "AIONER", "CellLine", "cell_line", ()),
+    # BioBERT NER is run as three fine-tuned checkpoints (gene / disease /
+    # chemical) merged under one source; span only, no normalization.
+    AnnotatorEntityTypeSpec("biobert", "BioBERT", "Gene / protein", "gene", ()),
+    AnnotatorEntityTypeSpec("biobert", "BioBERT", "Disease", "disease", ()),
+    AnnotatorEntityTypeSpec("biobert", "BioBERT", "Chemical / drug", "drug", ()),
     # ClinicalBERT (i2b2) emits problem / test / treatment. These are clinical
     # categories with no exact match in the canonical biomedical set (problem is
     # broader than disease, treatment broader than drug), so they are kept as their
@@ -316,6 +321,24 @@ ANNOTATOR_CAPABILITIES: dict[str, AnnotatorCapability] = {
             spec.canonical_entity_type: spec.database_ids
             for spec in ANNOTATOR_ENTITY_TYPE_SPECS
             if spec.annotator == "aioner"
+        },
+        normalization_fields=(),
+    ),
+    "biobert": AnnotatorCapability(
+        label="BioBERT",
+        tasks=("NER",),
+        entity_types=tuple(
+            dict.fromkeys(
+                spec.canonical_entity_type
+                for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+                if spec.annotator == "biobert"
+            )
+        ),
+        normalization_status="not_returned",
+        normalization_databases={
+            spec.canonical_entity_type: spec.database_ids
+            for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+            if spec.annotator == "biobert"
         },
         normalization_fields=(),
     ),

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -17,6 +17,11 @@ from bio_annotation.annotators.apollo import (
     annotate_with_apollo,
 )
 from bio_annotation.annotators.bern2 import annotate_with_bern2
+from bio_annotation.annotators.biobert import (
+    BIOBERT_INSTALL_HINT,
+    annotate_with_biobert,
+    load_biobert_pipelines,
+)
 from bio_annotation.annotators.clinicalbert import (
     CLINICALBERT_INSTALL_HINT,
     DEFAULT_CLINICALBERT_MODEL,
@@ -52,7 +57,7 @@ from bio_annotation.preprocessing.document_loader import (
 from bio_annotation.schemas.document import Document
 from bio_annotation.schemas.entity import Annotation
 
-SUPPORTED_ANNOTATORS = {"bern2", "flair", "pubtator3", "aioner", "clinicalbert", "apollo", "d4data", "medcat", *STANZA_ANNOTATORS}
+SUPPORTED_ANNOTATORS = {"bern2", "flair", "pubtator3", "aioner", "clinicalbert", "biobert", "apollo", "d4data", "medcat", *STANZA_ANNOTATORS}
 FLAIR_INSTALL_HINT = (
     "The Flair annotator requires the optional Flair dependency. "
     "Install it with: uv sync --extra flair"
@@ -70,6 +75,7 @@ def run_pipeline_from_config(
     flair_spans_by_document: dict[str, list[Any]] | None = None,
     aioner_request_fn: Callable[[Document], Any] | None = None,
     clinicalbert_responses_by_document: dict[str, list[Any]] | None = None,
+    biobert_responses_by_document: dict[str, dict[str, Any]] | None = None,
     apollo_responses_by_document: dict[str, list[Any]] | None = None,
     d4data_responses_by_document: dict[str, list[Any]] | None = None,
     medcat_request_fn: Callable[[Document], Any] | None = None,
@@ -80,6 +86,7 @@ def run_pipeline_from_config(
         config,
         flair_spans_by_document=flair_spans_by_document,
         clinicalbert_responses_by_document=clinicalbert_responses_by_document,
+        biobert_responses_by_document=biobert_responses_by_document,
         apollo_responses_by_document=apollo_responses_by_document,
         d4data_responses_by_document=d4data_responses_by_document,
         stanza_entities_by_document=stanza_entities_by_document,
@@ -111,6 +118,7 @@ def run_pipeline_from_config(
         flair_spans_by_document=flair_spans_by_document,
         aioner_request_fn=aioner_request_fn,
         clinicalbert_responses_by_document=clinicalbert_responses_by_document,
+        biobert_responses_by_document=biobert_responses_by_document,
         apollo_responses_by_document=apollo_responses_by_document,
         d4data_responses_by_document=d4data_responses_by_document,
         medcat_request_fn=medcat_request_fn,
@@ -136,6 +144,7 @@ def build_pipeline_output(
     flair_spans_by_document: dict[str, list[Any]] | None = None,
     aioner_request_fn: Callable[[Document], Any] | None = None,
     clinicalbert_responses_by_document: dict[str, list[Any]] | None = None,
+    biobert_responses_by_document: dict[str, dict[str, Any]] | None = None,
     apollo_responses_by_document: dict[str, list[Any]] | None = None,
     d4data_responses_by_document: dict[str, list[Any]] | None = None,
     medcat_request_fn: Callable[[Document], Any] | None = None,
@@ -172,6 +181,12 @@ def build_pipeline_output(
             clinicalbert_pipeline = _load_clinicalbert_pipeline(clinicalbert_options["model"])
         except Exception as exc:
             logger.warning("clinicalbert unavailable: %s", exc)
+    biobert_pipelines = None
+    if "biobert" in enabled_annotators and biobert_responses_by_document is None:
+        try:
+            biobert_pipelines = load_biobert_pipelines()
+        except Exception as exc:
+            logger.warning("biobert unavailable: %s", exc)
     apollo_pipeline = None
     if "apollo" in enabled_annotators and apollo_responses_by_document is None:
         try:
@@ -222,6 +237,12 @@ def build_pipeline_output(
             ),
             clinicalbert_pipeline=clinicalbert_pipeline,
             clinicalbert_options=clinicalbert_options,
+            biobert_response=(
+                biobert_responses_by_document.get(document.document_id)
+                if biobert_responses_by_document is not None
+                else None
+            ),
+            biobert_pipelines=biobert_pipelines,
             apollo_response=(
                 apollo_responses_by_document.get(document.document_id)
                 if apollo_responses_by_document is not None
@@ -509,6 +530,8 @@ def run_selected_annotators(
     clinicalbert_response: Any = None,
     clinicalbert_pipeline: Any = None,
     clinicalbert_options: dict[str, Any] | None = None,
+    biobert_response: Any = None,
+    biobert_pipelines: Any = None,
     apollo_response: Any = None,
     apollo_pipeline: Any = None,
     apollo_options: dict[str, Any] | None = None,
@@ -535,6 +558,8 @@ def run_selected_annotators(
         clinicalbert_response=clinicalbert_response,
         clinicalbert_pipeline=clinicalbert_pipeline,
         clinicalbert_options=clinicalbert_options,
+        biobert_response=biobert_response,
+        biobert_pipelines=biobert_pipelines,
         apollo_response=apollo_response,
         apollo_pipeline=apollo_pipeline,
         apollo_options=apollo_options,
@@ -565,6 +590,8 @@ def run_selected_annotators_with_status(
     clinicalbert_response: Any = None,
     clinicalbert_pipeline: Any = None,
     clinicalbert_options: dict[str, Any] | None = None,
+    biobert_response: Any = None,
+    biobert_pipelines: Any = None,
     apollo_response: Any = None,
     apollo_pipeline: Any = None,
     apollo_options: dict[str, Any] | None = None,
@@ -664,6 +691,12 @@ def run_selected_annotators_with_status(
                     pipeline=clinicalbert_pipeline,
                     model=clinicalbert_options.get("model") if clinicalbert_options else None,
                 )
+            elif annotator == "biobert":
+                results[annotator] = annotate_with_biobert(
+                    document,
+                    response=biobert_response,
+                    pipelines=biobert_pipelines,
+                )
             elif annotator == "apollo":
                 results[annotator] = annotate_with_apollo(
                     document,
@@ -729,7 +762,7 @@ def run_selected_annotators_with_status(
 
 def flatten_annotations(results: dict[str, list[Annotation]]) -> list[Annotation]:
     annotations: list[Annotation] = []
-    for source in ("bern2", "flair", "pubtator3", "aioner", "apollo", "clinicalbert", "d4data", "medcat", *STANZA_ANNOTATORS):
+    for source in ("bern2", "flair", "pubtator3", "aioner", "apollo", "clinicalbert", "biobert", "d4data", "medcat", *STANZA_ANNOTATORS):
         annotations.extend(results.get(source, []))
     return annotations
 
@@ -936,6 +969,11 @@ def _no_annotations_reason(annotator: str) -> str:
             "No annotations returned. The ClinicalBERT model may be unavailable/not "
             "downloaded (uv sync --extra clinicalbert), or it found no entities."
         )
+    if annotator == "biobert":
+        return (
+            "No annotations returned. The BioBERT models may be unavailable/not "
+            "downloaded (uv sync --extra biobert), or they found no entities."
+        )
     if annotator == "apollo":
         return (
             "No annotations returned. The apollo model may be unavailable/not "
@@ -1115,6 +1153,7 @@ def validate_optional_annotator_dependencies(
     *,
     flair_spans_by_document: dict[str, list[Any]] | None = None,
     clinicalbert_responses_by_document: dict[str, list[Any]] | None = None,
+    biobert_responses_by_document: dict[str, dict[str, Any]] | None = None,
     apollo_responses_by_document: dict[str, list[Any]] | None = None,
     d4data_responses_by_document: dict[str, list[Any]] | None = None,
     stanza_entities_by_document: dict[str, dict[str, list[Any]]] | None = None,
@@ -1137,6 +1176,12 @@ def validate_optional_annotator_dependencies(
         and (find_spec("transformers") is None or find_spec("torch") is None)
     ):
         raise ValueError(CLINICALBERT_INSTALL_HINT)
+    if (
+        "biobert" in config.annotators
+        and biobert_responses_by_document is None
+        and (find_spec("transformers") is None or find_spec("torch") is None)
+    ):
+        raise ValueError(BIOBERT_INSTALL_HINT)
     if (
         "apollo" in config.annotators
         and apollo_responses_by_document is None

--- a/src/bio_annotation/terminal_ui.py
+++ b/src/bio_annotation/terminal_ui.py
@@ -204,7 +204,7 @@ def collect_terminal_ui_answers(*, input_fn: InputFn, output_fn: OutputFn) -> Te
         default_values=[
             value
             for value, _ in ANNOTATOR_CHOICES
-            if value not in {"aioner", "clinicalbert", "apollo", "d4data", "medcat", *STANZA_ANNOTATORS}
+            if value not in {"aioner", "clinicalbert", "biobert", "apollo", "d4data", "medcat", *STANZA_ANNOTATORS}
         ],
         validate_values=_validate_selected_annotators,
     )

--- a/tests/test_annotators.py
+++ b/tests/test_annotators.py
@@ -706,6 +706,24 @@ def test_biobert_adapter_uses_request_fn_and_drops_punctuation() -> None:
     assert annotations[0].source == "biobert"
 
 
+def test_biobert_adapter_drops_outside_zero_labels() -> None:
+    document = sample_document()
+    # The diseases checkpoint mislabels its "outside" tag as "0" (not "O"), so the
+    # pipeline emits bogus "0" spans over plain text; those must be dropped.
+    response = {
+        "disease": [
+            {"entity_group": "0", "score": 1.0, "word": "PTEN and"},
+            {"entity_group": "DISEASE", "score": 0.99, "word": "glioblastoma"},
+            {"entity_group": "0", "score": 1.0, "word": "are biomarkers in"},
+        ],
+    }
+
+    annotations = annotate_with_biobert(document, response=response)
+
+    assert [a.span_text for a in annotations] == ["glioblastoma"]
+    assert annotations[0].entity_type == "disease"
+
+
 def test_aioner_windows_runner_uses_posix_paths_and_utf8(monkeypatch, tmp_path) -> None:
     # The Windows runner must hand AIONER forward-slash paths (it splits the model
     # path on "/") and decode the subprocess as UTF-8. Imported directly so the

--- a/tests/test_annotators.py
+++ b/tests/test_annotators.py
@@ -24,6 +24,10 @@ from bio_annotation.annotators.apollo import (
     annotate_with_apollo,
 )
 from bio_annotation.annotators.bern2 import annotate_with_bern2, call_bern2
+from bio_annotation.annotators.biobert import (
+    DEFAULT_BIOBERT_MODELS,
+    annotate_with_biobert,
+)
 from bio_annotation.annotators.d4data import (
     DEFAULT_D4DATA_MODEL,
     annotate_with_d4data,
@@ -641,6 +645,65 @@ def test_clinicalbert_adapter_trims_leading_articles_and_drops_noise() -> None:
     spans = [annotation.span_text for annotation in annotations]
     assert spans == ["stop codon", "11-base pair insertion", "breast cancer"]
     assert all(annotation.entity_type == "problem" for annotation in annotations)
+
+
+def test_biobert_adapter_merges_per_model_responses() -> None:
+    document = sample_document()
+    # One HuggingFace payload per checkpoint; the producing model sets the type.
+    response = {
+        "gene": [{"entity_group": "GENE", "score": 0.98, "word": "PTEN"}],
+        "disease": [{"entity_group": "DISEASE", "score": 0.95, "word": "glioblastoma"}],
+        "drug": [{"entity_group": "CHEMICAL", "score": 0.90, "word": "miR-21"}],
+    }
+
+    annotations = annotate_with_biobert(document, response=response)
+
+    assert all(annotation.source == "biobert" for annotation in annotations)
+    assert {(a.span_text, a.entity_type) for a in annotations} == {
+        ("PTEN", "gene"),
+        ("glioblastoma", "disease"),
+        ("miR-21", "drug"),
+    }
+
+
+def test_biobert_adapter_loads_one_pipeline_per_model() -> None:
+    document = sample_document()
+    loaded: list[str] = []
+    label_by_model = {
+        "alvaroalon2/biobert_genetic_ner": "GENE",
+        "alvaroalon2/biobert_diseases_ner": "DISEASE",
+        "alvaroalon2/biobert_chemical_ner": "CHEMICAL",
+    }
+
+    def fake_loader(model: str):
+        loaded.append(model)
+        label = label_by_model[model]
+        return lambda text: [{"entity_group": label, "score": 0.9, "word": "PTEN"}]
+
+    annotations = annotate_with_biobert(document, pipeline_loader=fake_loader)
+
+    # One pipeline loaded per configured checkpoint, all merged under "biobert".
+    assert loaded == list(DEFAULT_BIOBERT_MODELS.values())
+    assert all(a.source == "biobert" for a in annotations)
+    assert sorted(a.entity_type for a in annotations) == ["disease", "drug", "gene"]
+
+
+def test_biobert_adapter_uses_request_fn_and_drops_punctuation() -> None:
+    document = sample_document()
+
+    def fake_request(doc: Document) -> dict[str, list[dict[str, object]]]:
+        return {
+            "gene": [
+                {"entity_group": "GENE", "score": 0.9, "word": "PTEN"},
+                {"entity_group": "GENE", "score": 0.4, "word": "-"},
+            ],
+        }
+
+    annotations = annotate_with_biobert(document, request_fn=fake_request)
+
+    assert [a.span_text for a in annotations] == ["PTEN"]
+    assert annotations[0].entity_type == "gene"
+    assert annotations[0].source == "biobert"
 
 
 def test_aioner_windows_runner_uses_posix_paths_and_utf8(monkeypatch, tmp_path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2560,6 +2560,10 @@ benchmarks = [
     { name = "pandas" },
     { name = "tabulate" },
 ]
+biobert = [
+    { name = "torch" },
+    { name = "transformers" },
+]
 clinicalbert = [
     { name = "torch" },
     { name = "transformers" },
@@ -2590,14 +2594,16 @@ requires-dist = [
     { name = "stanza", marker = "extra == 'stanza'", specifier = ">=1.8" },
     { name = "tabulate", marker = "extra == 'benchmarks'", specifier = ">=0.9" },
     { name = "torch", marker = "extra == 'apollo'", specifier = ">=2.0" },
+    { name = "torch", marker = "extra == 'biobert'", specifier = ">=2.0" },
     { name = "torch", marker = "extra == 'clinicalbert'", specifier = ">=2.0" },
     { name = "torch", marker = "extra == 'd4data'", specifier = ">=2.0" },
-    { name = "totalannotator", extras = ["flair", "clinicalbert", "apollo", "d4data", "stanza", "benchmarks"], marker = "extra == 'all'" },
+    { name = "totalannotator", extras = ["flair", "clinicalbert", "biobert", "apollo", "d4data", "stanza", "benchmarks"], marker = "extra == 'all'" },
     { name = "transformers", marker = "extra == 'apollo'", specifier = ">=4.30,<5" },
+    { name = "transformers", marker = "extra == 'biobert'", specifier = ">=4.30,<5" },
     { name = "transformers", marker = "extra == 'clinicalbert'", specifier = ">=4.30,<5" },
     { name = "transformers", marker = "extra == 'd4data'", specifier = ">=4.30,<5" },
 ]
-provides-extras = ["flair", "clinicalbert", "apollo", "d4data", "stanza", "benchmarks", "all"]
+provides-extras = ["flair", "clinicalbert", "biobert", "apollo", "d4data", "stanza", "benchmarks", "all"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.0" }]


### PR DESCRIPTION
# Summary
Adds a `biobert` annotator. BioBERT NER ships as per-entity checkpoints, so it runs three HuggingFace models (gene / disease / chemical) and merges them under one `biobert` source. Span only, emits canonical gene / disease / drug.Transformers and torch added.

Note: the diseases checkpoint mislabels its "outside" tag as "0" instead of "O", so the parser reads the label to drop those bogus spans (def test_biobert_adapter_drops_outside_zero_labels in test_annotators.py ).

