### PR TITLE
Add Stanza i2b2, radiology and AnatEM NER models

### DIFF
--- a/src/bio_annotation/entity_proposal/stanza_proposer.py
+++ b/src/bio_annotation/entity_proposal/stanza_proposer.py
@@ -7,8 +7,29 @@ from bio_annotation.entity_proposal._shared import make_annotation
 from bio_annotation.schemas.document import Document
 from bio_annotation.schemas.entity import Annotation
 
-STANZA_MODELS: tuple[str, ...] = ("bc5cdr", "bionlp13cg", "jnlpba")
+STANZA_MODELS: tuple[str, ...] = (
+    "bc5cdr",
+    "bionlp13cg",
+    "jnlpba",
+    "i2b2",
+    "radiology",
+    "anatem",
+)
 DEFAULT_STANZA_PACKAGE = "craft"
+
+# Clinical Stanza models are tokenized with the MIMIC package rather than the
+# CRAFT biomedical tokenizer. Models absent here (including the biomedical
+# anatem) fall back to DEFAULT_STANZA_PACKAGE; an explicit config package still
+# overrides both.
+STANZA_MODEL_PACKAGES: dict[str, str] = {
+    "i2b2": "mimic",
+    "radiology": "mimic",
+}
+
+
+def default_package_for_model(model: str) -> str:
+    return STANZA_MODEL_PACKAGES.get(model, DEFAULT_STANZA_PACKAGE)
+
 
 STANZA_INSTALL_HINT = (
     "The Stanza annotators require the optional Stanza dependency. "
@@ -26,6 +47,35 @@ def stanza_model_for_annotator(annotator: str) -> str:
 
 STANZA_ANNOTATORS: tuple[str, ...] = tuple(stanza_source(model) for model in STANZA_MODELS)
 
+# Clinical Stanza models (i2b2, radiology) often tag a noun phrase together with
+# its leading determiner on out-of-domain text (e.g. "a stop codon", "the large
+# mass"). Strip the determiner and keep character offsets aligned. Ordered so
+# longer determiners match before shorter ones.
+_LEADING_DETERMINERS = ("these", "those", "this", "the", "an", "a")
+_DETERMINER_WORDS = frozenset(_LEADING_DETERMINERS)
+
+
+def _strip_leading_determiner(
+    text: str, start: int | None, end: int | None
+) -> tuple[str, int | None, int | None]:
+    lowered = text.lower()
+    for determiner in _LEADING_DETERMINERS:
+        if lowered.startswith(determiner + " "):
+            removed = len(text) - len(text[len(determiner):].lstrip())
+            trimmed = text[removed:]
+            if isinstance(start, int):
+                return trimmed, start + removed, end
+            return trimmed, start, end
+    return text, start, end
+
+
+def _is_noise_span(text: str) -> bool:
+    """True for out-of-domain junk: a bare determiner or lone punctuation like "-"."""
+    core = text.strip("-/ \t")
+    if len(core) < 2 or not any(ch.isalnum() for ch in core):
+        return True
+    return text.strip().lower() in _DETERMINER_WORDS
+
 
 def parse_stanza_entities(
     document: Document,
@@ -38,14 +88,19 @@ def parse_stanza_entities(
         text = getattr(entity, "text", None)
         if not text:
             continue
+        start = getattr(entity, "start_char", None)
+        end = getattr(entity, "end_char", None)
+        text, start, end = _strip_leading_determiner(text, start, end)
+        if not text or _is_noise_span(text):
+            continue
         annotations.append(
             make_annotation(
                 document=document,
                 source=source,
                 span_text=text,
                 entity_type=getattr(entity, "type", None),
-                start=getattr(entity, "start_char", None),
-                end=getattr(entity, "end_char", None),
+                start=start,
+                end=end,
             )
         )
     return annotations
@@ -82,7 +137,7 @@ def annotate_with_stanza(
 
     if pipeline is None:
         loader = pipeline_loader or _load_stanza_pipeline
-        pipeline = loader(package or DEFAULT_STANZA_PACKAGE, model)
+        pipeline = loader(package or default_package_for_model(model), model)
 
     parsed = pipeline(document.text)
     return parse_stanza_entities(document, getattr(parsed, "ents", []) or [], source=source)

--- a/src/bio_annotation/entity_types.py
+++ b/src/bio_annotation/entity_types.py
@@ -113,6 +113,22 @@ STANZA_ENTITY_TYPE_SPECS: tuple[tuple[str, str, str, str], ...] = (
     ("stanza_jnlpba", "Stanza JNLPBA", "RNA", "rna"),
     ("stanza_jnlpba", "Stanza JNLPBA", "Cell line", "cell_line"),
     ("stanza_jnlpba", "Stanza JNLPBA", "Cell type", "cell_type"),
+    # Stanza i2b2 is a clinical model (2010 i2b2/VA) emitting problem / test /
+    # treatment, the same clinical categories ClinicalBERT uses.
+    ("stanza_i2b2", "Stanza i2b2", "Problem", "problem"),
+    ("stanza_i2b2", "Stanza i2b2", "Test", "test"),
+    ("stanza_i2b2", "Stanza i2b2", "Treatment", "treatment"),
+    # Stanza radiology is a clinical model (Stanford radiology reports) emitting
+    # anatomy / observation / their modifiers / uncertainty. These radiology
+    # categories have no biomedical equivalent, so they are kept as their own types.
+    ("stanza_radiology", "Stanza radiology", "Anatomy", "anatomy"),
+    ("stanza_radiology", "Stanza radiology", "Anatomy modifier", "anatomy_modifier"),
+    ("stanza_radiology", "Stanza radiology", "Observation", "observation"),
+    ("stanza_radiology", "Stanza radiology", "Observation modifier", "observation_modifier"),
+    ("stanza_radiology", "Stanza radiology", "Uncertainty", "uncertainty"),
+    # Stanza AnatEM is a biomedical model (Anatomical Entity Mention corpus) with a
+    # single anatomical entity type; it uses the default CRAFT biomedical tokenizer.
+    ("stanza_anatem", "Stanza AnatEM", "Anatomy", "anatomy"),
 )
 
 
@@ -436,6 +452,60 @@ ANNOTATOR_CAPABILITIES: dict[str, AnnotatorCapability] = {
             spec.canonical_entity_type: spec.database_ids
             for spec in ANNOTATOR_ENTITY_TYPE_SPECS
             if spec.annotator == "stanza_jnlpba"
+        },
+        normalization_fields=(),
+    ),
+    "stanza_i2b2": AnnotatorCapability(
+        label="Stanza i2b2",
+        tasks=("NER",),
+        entity_types=tuple(
+            dict.fromkeys(
+                spec.canonical_entity_type
+                for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+                if spec.annotator == "stanza_i2b2"
+            )
+        ),
+        normalization_status="not_returned",
+        normalization_databases={
+            spec.canonical_entity_type: spec.database_ids
+            for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+            if spec.annotator == "stanza_i2b2"
+        },
+        normalization_fields=(),
+    ),
+    "stanza_radiology": AnnotatorCapability(
+        label="Stanza radiology",
+        tasks=("NER",),
+        entity_types=tuple(
+            dict.fromkeys(
+                spec.canonical_entity_type
+                for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+                if spec.annotator == "stanza_radiology"
+            )
+        ),
+        normalization_status="not_returned",
+        normalization_databases={
+            spec.canonical_entity_type: spec.database_ids
+            for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+            if spec.annotator == "stanza_radiology"
+        },
+        normalization_fields=(),
+    ),
+    "stanza_anatem": AnnotatorCapability(
+        label="Stanza AnatEM",
+        tasks=("NER",),
+        entity_types=tuple(
+            dict.fromkeys(
+                spec.canonical_entity_type
+                for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+                if spec.annotator == "stanza_anatem"
+            )
+        ),
+        normalization_status="not_returned",
+        normalization_databases={
+            spec.canonical_entity_type: spec.database_ids
+            for spec in ANNOTATOR_ENTITY_TYPE_SPECS
+            if spec.annotator == "stanza_anatem"
         },
         normalization_fields=(),
     ),

--- a/src/bio_annotation/pipeline_runner.py
+++ b/src/bio_annotation/pipeline_runner.py
@@ -34,7 +34,6 @@ from bio_annotation.annotators.medcat import annotate_with_medcat
 from bio_annotation.annotators.pubtator3 import annotate_with_pubtator3
 from bio_annotation.annotators.stanza import annotate_with_stanza
 from bio_annotation.entity_proposal.stanza_proposer import (
-    DEFAULT_STANZA_PACKAGE,
     STANZA_ANNOTATORS,
     STANZA_INSTALL_HINT,
     stanza_model_for_annotator,
@@ -1217,10 +1216,13 @@ def _read_aioner_options(settings: dict[str, object]) -> dict[str, Any]:
 
 def _read_stanza_options(settings: dict[str, object]) -> dict[str, Any]:
     package = settings.get("package")
+    # Leave package unset (None) when the config omits it, so annotate_with_stanza
+    # can apply the model-specific default (mimic for i2b2/radiology, craft
+    # otherwise). Defaulting to craft here would override that per-model choice.
     return {
         "package": package.strip()
         if isinstance(package, str) and package.strip()
-        else DEFAULT_STANZA_PACKAGE,
+        else None,
     }
 
 

--- a/src/bio_annotation/terminal_ui.py
+++ b/src/bio_annotation/terminal_ui.py
@@ -20,7 +20,6 @@ from bio_annotation.entity_proposal.clinicalbert_proposer import DEFAULT_CLINICA
 from bio_annotation.entity_proposal.d4data_proposer import DEFAULT_D4DATA_MODEL
 from bio_annotation.entity_proposal.medcat_proposer import DEFAULT_MEDCAT_API_URL
 from bio_annotation.entity_proposal.stanza_proposer import (
-    DEFAULT_STANZA_PACKAGE,
     STANZA_ANNOTATORS,
 )
 from bio_annotation.entity_types import (
@@ -344,7 +343,7 @@ def build_terminal_ui_config_text(answers: TerminalUIAnswers, paths: RunPaths) -
         lines += ["", "[annotators.medcat]", 'runtime = "remote_api"', f"endpoint = {_toml_string(medcat_config_endpoint())}", "min_acc = 0.3"]
     for stanza_annotator in STANZA_ANNOTATORS:
         if stanza_annotator in answers.annotators:
-            lines += ["", f"[annotators.{stanza_annotator}]", 'runtime = "local"', f"package = {_toml_string(DEFAULT_STANZA_PACKAGE)}"]
+            lines += ["", f"[annotators.{stanza_annotator}]", 'runtime = "local"']
     lines += ["", "[filters]", f"entity_types = {_toml_string_list(answers.entity_types)}", "", "[output]", f"path = {_toml_string(str(paths.results_path))}", ""]
     return "\n".join(lines)
 

--- a/tests/test_annotators.py
+++ b/tests/test_annotators.py
@@ -933,6 +933,132 @@ def test_stanza_jnlpba_loads_fixed_model_and_keeps_cell_type_distinct() -> None:
     ]
 
 
+def test_stanza_i2b2_maps_clinical_types_and_stamps_source() -> None:
+    document = sample_document()
+    entities = [
+        FakeStanzaEntity("glioblastoma", "PROBLEM", 15, 27),
+        FakeStanzaEntity("MRI", "TEST", 0, 3),
+        FakeStanzaEntity("cisplatin", "TREATMENT", 40, 49),
+    ]
+
+    annotations = annotate_with_stanza(document, "i2b2", entities=entities)
+
+    assert [a.entity_type for a in annotations] == ["problem", "test", "treatment"]
+    assert all(a.source == "stanza_i2b2" for a in annotations)
+
+
+def test_stanza_i2b2_defaults_to_mimic_tokenizer_package() -> None:
+    from bio_annotation.entity_proposal.stanza_proposer import default_package_for_model
+
+    loaded: list[tuple[str, str]] = []
+
+    def fake_loader(package: str, model: str):
+        loaded.append((package, model))
+        return lambda text: FakeStanzaDoc([])
+
+    annotate_with_stanza(sample_document(), "i2b2", pipeline_loader=fake_loader)
+
+    # i2b2 is clinical, so it must default to the MIMIC tokenizer, not CRAFT.
+    assert loaded == [("mimic", "i2b2")]
+    assert default_package_for_model("i2b2") == "mimic"
+    assert default_package_for_model("bc5cdr") == "craft"
+
+
+def test_stanza_i2b2_trims_leading_determiners_and_drops_noise() -> None:
+    document = sample_document()
+    entities = [
+        FakeStanzaEntity("a stop codon", "TREATMENT", 0, 12),
+        FakeStanzaEntity("This protein", "TEST", 13, 25),
+        FakeStanzaEntity("the breast and ovarian cancer", "PROBLEM", 26, 55),
+        FakeStanzaEntity("a", "PROBLEM", 56, 57),
+        FakeStanzaEntity("-", "PROBLEM", 58, 59),
+    ]
+
+    annotations = annotate_with_stanza(document, "i2b2", entities=entities)
+
+    spans = [a.span_text for a in annotations]
+    assert spans == ["stop codon", "protein", "breast and ovarian cancer"]
+
+
+def test_stanza_radiology_maps_clinical_types_and_stamps_source() -> None:
+    document = sample_document()
+    entities = [
+        FakeStanzaEntity("liver", "ANATOMY", 0, 5),
+        FakeStanzaEntity("right", "ANATOMY_MODIFIER", 6, 11),
+        FakeStanzaEntity("mass", "OBSERVATION", 12, 16),
+        FakeStanzaEntity("large", "OBSERVATION_MODIFIER", 17, 22),
+        FakeStanzaEntity("possible", "UNCERTAINTY", 23, 31),
+    ]
+
+    annotations = annotate_with_stanza(document, "radiology", entities=entities)
+
+    assert [a.entity_type for a in annotations] == [
+        "anatomy",
+        "anatomy_modifier",
+        "observation",
+        "observation_modifier",
+        "uncertainty",
+    ]
+    assert all(a.source == "stanza_radiology" for a in annotations)
+
+
+def test_stanza_radiology_defaults_to_mimic_tokenizer_package() -> None:
+    from bio_annotation.entity_proposal.stanza_proposer import default_package_for_model
+
+    loaded: list[tuple[str, str]] = []
+
+    def fake_loader(package: str, model: str):
+        loaded.append((package, model))
+        return lambda text: FakeStanzaDoc([])
+
+    annotate_with_stanza(sample_document(), "radiology", pipeline_loader=fake_loader)
+
+    # radiology is clinical, so it must default to the MIMIC tokenizer, not CRAFT.
+    assert loaded == [("mimic", "radiology")]
+    assert default_package_for_model("radiology") == "mimic"
+    assert default_package_for_model("bc5cdr") == "craft"
+
+
+def test_stanza_radiology_trims_leading_determiners_and_drops_noise() -> None:
+    document = sample_document()
+    entities = [
+        FakeStanzaEntity("the large mass", "OBSERVATION", 0, 14),
+        FakeStanzaEntity("a", "OBSERVATION", 15, 16),
+        FakeStanzaEntity("-", "ANATOMY", 17, 18),
+        FakeStanzaEntity("liver", "ANATOMY", 19, 24),
+    ]
+
+    annotations = annotate_with_stanza(document, "radiology", entities=entities)
+
+    assert [a.span_text for a in annotations] == ["large mass", "liver"]
+
+
+def test_stanza_anatem_maps_anatomy_and_stamps_source() -> None:
+    document = sample_document()
+    entities = [
+        FakeStanzaEntity("liver", "ANATOMY", 0, 5),
+        FakeStanzaEntity("lymph nodes", "ANATOMY", 6, 17),
+    ]
+
+    annotations = annotate_with_stanza(document, "anatem", entities=entities)
+
+    assert [a.entity_type for a in annotations] == ["anatomy", "anatomy"]
+    assert all(a.source == "stanza_anatem" for a in annotations)
+
+
+def test_stanza_anatem_uses_craft_biomedical_tokenizer_package() -> None:
+    loaded: list[tuple[str, str]] = []
+
+    def fake_loader(package: str, model: str):
+        loaded.append((package, model))
+        return lambda text: FakeStanzaDoc([])
+
+    annotate_with_stanza(sample_document(), "anatem", pipeline_loader=fake_loader)
+
+    # AnatEM is biomedical, so it uses the default CRAFT tokenizer (not MIMIC).
+    assert loaded == [("craft", "anatem")]
+
+
 def test_run_all_annotators_returns_consistent_result_map() -> None:
     document = sample_document()
     results = run_all_annotators(

--- a/tests/test_pipeline_runner.py
+++ b/tests/test_pipeline_runner.py
@@ -18,6 +18,7 @@ from bio_annotation.pipeline_runner import (
     _read_bern2_options,
     _read_flair_options,
     _read_pubtator3_options,
+    _read_stanza_options,
     build_keyword_annotations,
     filter_annotations_by_type,
     run_pipeline_from_config,
@@ -681,3 +682,17 @@ def test_filter_annotations_by_type_normalizes_entity_labels() -> None:
     filtered = filter_annotations_by_type(annotations, ["gene"])
 
     assert [annotation.entity_type for annotation in filtered] == ["Gene"]
+
+
+def test_read_stanza_options_omitted_package_defaults_to_none():
+    # When the config omits package, it must stay None so annotate_with_stanza
+    # applies the model-specific default (mimic for i2b2/radiology, craft otherwise).
+    # A stray craft default here would override that per-model choice.
+    assert _read_stanza_options({})["package"] is None
+    assert _read_stanza_options({"package": ""})["package"] is None
+    assert _read_stanza_options({"package": "  "})["package"] is None
+
+
+def test_read_stanza_options_explicit_package_is_kept():
+    assert _read_stanza_options({"package": "mimic"})["package"] == "mimic"
+    assert _read_stanza_options({"package": " craft "})["package"] == "craft"


### PR DESCRIPTION
Adds the 3 Stanza NER models in this PR :

- stanza_i2b2 (clinical): problem / test / treatment
- stanza_radiology (clinical): anatomy / anatomy_modifier / observation / observation_modifier / uncertainty
- stanza_anatem (biomedical): anatomy

The two clinical models default to the MIMIC tokenizer via a per-model package map; anatem stays on the biomedical CRAFT default. Config package still overrides. parse_stanza_entities also strips leading determiners (the, this...etc) and drops bare-determiner/punctuation noise, so the clinical models stay clean on out-of-domain text.


